### PR TITLE
feat: add home render content for IBC core and transfer realms

### DIFF
--- a/gno.land/r/aib/ibc/apps/transfer/render.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/render.gno
@@ -3,6 +3,7 @@ package transfer
 import (
 	"chain"
 	"chain/runtime"
+	"strings"
 
 	"gno.land/p/aib/jsonpage"
 	"gno.land/p/nt/mux/v0"
@@ -23,8 +24,21 @@ func Render(path string) string {
 }
 
 func renderHome(w *mux.ResponseWriter, r *mux.Request) {
-	// TODO list available endpoints ?
-	w.Write(`["Hello IBC transfer!"]`)
+	var out strings.Builder
+	out.WriteString("# IBC transfer\n\n")
+	out.WriteString("ICS-20 style transfer state and voucher token queries.\n\n")
+	out.WriteString("## Dashboard\n\n")
+	out.WriteString(ufmt.Sprintf("- Known IBC denoms: `%d`\n", denoms.Size()))
+	out.WriteString(ufmt.Sprintf("- Escrow denoms: `%d`\n", totalEscrow.Size()))
+	out.WriteString(ufmt.Sprintf("- Voucher GRC20 tokens: `%d`\n\n", grc20tokens.Size()))
+	out.WriteString("## Endpoints\n\n")
+	out.WriteString("- [`denoms`](/r/aib/ibc/apps/transfer:denoms): list known IBC denoms (`?page`, `?limit`)\n")
+	out.WriteString("- `denoms/ibc/{hash}`: get metadata for an IBC denom\n")
+	out.WriteString("- `total_escrow/{denom}`: get total escrow tracked for a base denom\n")
+	out.WriteString("- `grc20/ibc/{hash}`: get GRC20 voucher token metadata\n")
+	out.WriteString("- `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address\n\n")
+	out.WriteString("Start with [`denoms`](/r/aib/ibc/apps/transfer:denoms) to discover an IBC denom hash.\n")
+	w.Write(out.String())
 }
 
 func renderDenoms(w *mux.ResponseWriter, r *mux.Request) {

--- a/gno.land/r/aib/ibc/apps/transfer/render.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/render.gno
@@ -37,7 +37,20 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	out.WriteString("- `total_escrow/{denom}`: get total escrow tracked for a base denom\n")
 	out.WriteString("- `grc20/ibc/{hash}`: get GRC20 voucher token metadata\n")
 	out.WriteString("- `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address\n\n")
-	out.WriteString("Start with [`denoms`](/r/aib/ibc/apps/transfer:denoms) to discover an IBC denom hash.\n")
+	out.WriteString("## Known denoms\n\n")
+	if denoms.Size() == 0 {
+		out.WriteString("No denom traces yet. Receive an IBC voucher, then refresh this page.\n")
+	} else {
+		denoms.IterateByOffset(0, denoms.Size(), func(_ string, v any) bool {
+			d := v.(Denom)
+			out.WriteString(ufmt.Sprintf(
+				"- `%s`: [metadata](/r/aib/ibc/apps/transfer:denoms/%s) | [GRC20](/r/aib/ibc/apps/transfer:grc20/%s)\n",
+				d.IBCDenom(), d.IBCDenom(), d.IBCDenom(),
+			))
+			out.WriteString(ufmt.Sprintf("  path: `%s`\n", d.Path()))
+			return false
+		})
+	}
 	w.Write(out.String())
 }
 

--- a/gno.land/r/aib/ibc/apps/transfer/render.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/render.gno
@@ -27,30 +27,63 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	var out strings.Builder
 	out.WriteString("# IBC transfer\n\n")
 	out.WriteString("ICS-20 style transfer state and voucher token queries.\n\n")
-	out.WriteString("## Dashboard\n\n")
-	out.WriteString(ufmt.Sprintf("- Known IBC denoms: `%d`\n", denoms.Size()))
-	out.WriteString(ufmt.Sprintf("- Escrow denoms: `%d`\n", totalEscrow.Size()))
-	out.WriteString(ufmt.Sprintf("- Voucher GRC20 tokens: `%d`\n\n", voucherTokens.Size()))
-	out.WriteString("## Endpoints\n\n")
+	out.WriteString(ufmt.Sprintf("## Vouchers (%d)\n\n", denoms.Size()))
+	if denoms.Size() > 0 {
+		out.WriteString("| Denom | Base | Path | Supply | GRC20 |\n")
+		out.WriteString("|-------|------|------|--------|-------|\n")
+		denoms.IterateByOffset(0, denoms.Size(), func(_ string, v any) bool {
+			d := v.(Denom)
+			ibcDenom := d.IBCDenom()
+			supply := ""
+			grc20link := ""
+			if inst := getVoucher(ibcDenom); inst != nil {
+				supply = ufmt.Sprintf("[%d](/r/aib/ibc/apps/transfer:voucher/%s)", inst.token.TotalSupply(), ibcDenom)
+				key := grc20regKey(ibcDenom)
+				// Shorten the hash suffix: "gno.land/r/.../transfer.CAEF9C..." → keep prefix + first 4 … last 4 of hash
+				dotIdx := strings.LastIndex(key, ".")
+				shortKey := key
+				if dotIdx != -1 {
+					hash := key[dotIdx+1:]
+					if len(hash) > 10 {
+						shortKey = key[:dotIdx+1] + hash[:4] + "…" + hash[len(hash)-4:]
+					}
+				}
+				const grc20regPath = "gno.land/r/demo/defi/grc20reg"
+				grc20link = ufmt.Sprintf("[%s](%s:%s)", shortKey, stripDomain(grc20regPath), key)
+			}
+			out.WriteString(ufmt.Sprintf(
+				"| [`%s`](/r/aib/ibc/apps/transfer:denoms/%s) | %s | %s | %s | %s |\n",
+				shortDenom(ibcDenom), ibcDenom, d.Base, d.Path(), supply, grc20link,
+			))
+			return false
+		})
+		out.WriteString("\n")
+	} else {
+		out.WriteString("No vouchers yet.\n\n")
+	}
+	out.WriteString(ufmt.Sprintf("## Escrow (%d)\n\n", totalEscrow.Size()))
+	if totalEscrow.Size() > 0 {
+		out.WriteString("| Denom | Amount |\n")
+		out.WriteString("|-------|--------|\n")
+		totalEscrow.IterateByOffset(0, totalEscrow.Size(), func(_ string, v any) bool {
+			c := v.(chain.Coin)
+			out.WriteString(ufmt.Sprintf(
+				"| [`%s`](/r/aib/ibc/apps/transfer:total_escrow/%s) | %d |\n",
+				c.Denom, c.Denom, c.Amount,
+			))
+			return false
+		})
+		out.WriteString("\n")
+	} else {
+		out.WriteString("No escrow yet.\n\n")
+	}
+	out.WriteString("## JSON endpoints\n\n")
 	out.WriteString("- [`denoms`](/r/aib/ibc/apps/transfer:denoms): list known IBC denoms (`?page`, `?limit`)\n")
 	out.WriteString("- `denoms/ibc/{hash}`: get metadata for an IBC denom\n")
 	out.WriteString("- `total_escrow/{denom}`: get total escrow tracked for a base denom\n")
-	out.WriteString("- `grc20/ibc/{hash}`: get GRC20 voucher token metadata\n")
-	out.WriteString("- `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address\n\n")
-	out.WriteString("## Known denoms\n\n")
-	if denoms.Size() == 0 {
-		out.WriteString("No denom traces yet. Receive an IBC voucher, then refresh this page.\n")
-	} else {
-		denoms.IterateByOffset(0, denoms.Size(), func(_ string, v any) bool {
-			d := v.(Denom)
-			out.WriteString(ufmt.Sprintf(
-				"- `%s`: [metadata](/r/aib/ibc/apps/transfer:denoms/%s) | [GRC20](/r/aib/ibc/apps/transfer:grc20/%s)\n",
-				d.IBCDenom(), d.IBCDenom(), d.IBCDenom(),
-			))
-			out.WriteString(ufmt.Sprintf("  path: `%s`\n", d.Path()))
-			return false
-		})
-	}
+	out.WriteString("- [`vouchers`](/r/aib/ibc/apps/transfer:vouchers): list voucher tokens (`?page`, `?limit`)\n")
+	out.WriteString("- `voucher/ibc/{hash}`: get voucher token metadata\n")
+	out.WriteString("- `voucher/ibc/{hash}/balance/{addr}`: get a voucher balance for an address\n\n")
 	w.Write(out.String())
 }
 
@@ -126,6 +159,30 @@ func renderVoucherBalance(w *mux.ResponseWriter, r *mux.Request) {
 		"address": json.StringNode("", addr),
 		"balance": json.NumberNode("", float64(balance)),
 	}))
+}
+
+// stripDomain removes the domain from a gno pkg path for use in URLs.
+// "gno.land/r/demo/foo" → "/r/demo/foo"
+func stripDomain(path string) string {
+	i := strings.Index(path, "/")
+	if i != -1 {
+		return path[i:]
+	}
+	return path
+}
+
+// shortDenom shortens an IBC denom hash for display.
+// "ibc/CAEF9CABC…9D0F" (ibc/ + first 4 + … + last 4)
+func shortDenom(ibcDenom string) string {
+	const prefix = "ibc/"
+	if !strings.HasPrefix(ibcDenom, prefix) {
+		return ibcDenom
+	}
+	hash := ibcDenom[len(prefix):]
+	if len(hash) > 10 {
+		return prefix + hash[:4] + "…" + hash[len(hash)-4:]
+	}
+	return ibcDenom
 }
 
 func renderNode(w *mux.ResponseWriter, n *json.Node) {

--- a/gno.land/r/aib/ibc/apps/transfer/render.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/render.gno
@@ -30,7 +30,7 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	out.WriteString("## Dashboard\n\n")
 	out.WriteString(ufmt.Sprintf("- Known IBC denoms: `%d`\n", denoms.Size()))
 	out.WriteString(ufmt.Sprintf("- Escrow denoms: `%d`\n", totalEscrow.Size()))
-	out.WriteString(ufmt.Sprintf("- Voucher GRC20 tokens: `%d`\n\n", grc20tokens.Size()))
+	out.WriteString(ufmt.Sprintf("- Voucher GRC20 tokens: `%d`\n\n", voucherTokens.Size()))
 	out.WriteString("## Endpoints\n\n")
 	out.WriteString("- [`denoms`](/r/aib/ibc/apps/transfer:denoms): list known IBC denoms (`?page`, `?limit`)\n")
 	out.WriteString("- `denoms/ibc/{hash}`: get metadata for an IBC denom\n")

--- a/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
@@ -25,4 +25,6 @@ func main() {
 // - `grc20/ibc/{hash}`: get GRC20 voucher token metadata
 // - `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address
 //
-// Start with [`denoms`](/r/aib/ibc/apps/transfer:denoms) to discover an IBC denom hash.
+// ## Known denoms
+//
+// No denom traces yet. Receive an IBC voucher, then refresh this page.

--- a/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import "gno.land/r/aib/ibc/apps/transfer"
+
+func main() {
+	println(transfer.Render(""))
+}
+
+// Output:
+// # IBC transfer
+//
+// ICS-20 style transfer state and voucher token queries.
+//
+// ## Dashboard
+//
+// - Known IBC denoms: `0`
+// - Escrow denoms: `0`
+// - Voucher GRC20 tokens: `0`
+//
+// ## Endpoints
+//
+// - [`denoms`](/r/aib/ibc/apps/transfer:denoms): list known IBC denoms (`?page`, `?limit`)
+// - `denoms/ibc/{hash}`: get metadata for an IBC denom
+// - `total_escrow/{denom}`: get total escrow tracked for a base denom
+// - `grc20/ibc/{hash}`: get GRC20 voucher token metadata
+// - `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address
+//
+// Start with [`denoms`](/r/aib/ibc/apps/transfer:denoms) to discover an IBC denom hash.

--- a/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z0b_render_home_filetest.gno
@@ -11,20 +11,19 @@ func main() {
 //
 // ICS-20 style transfer state and voucher token queries.
 //
-// ## Dashboard
+// ## Vouchers (0)
 //
-// - Known IBC denoms: `0`
-// - Escrow denoms: `0`
-// - Voucher GRC20 tokens: `0`
+// No vouchers yet.
 //
-// ## Endpoints
+// ## Escrow (0)
+//
+// No escrow yet.
+//
+// ## JSON endpoints
 //
 // - [`denoms`](/r/aib/ibc/apps/transfer:denoms): list known IBC denoms (`?page`, `?limit`)
 // - `denoms/ibc/{hash}`: get metadata for an IBC denom
 // - `total_escrow/{denom}`: get total escrow tracked for a base denom
-// - `grc20/ibc/{hash}`: get GRC20 voucher token metadata
-// - `grc20/ibc/{hash}/balance/{addr}`: get a GRC20 voucher balance for an address
-//
-// ## Known denoms
-//
-// No denom traces yet. Receive an IBC voucher, then refresh this page.
+// - [`vouchers`](/r/aib/ibc/apps/transfer:vouchers): list voucher tokens (`?page`, `?limit`)
+// - `voucher/ibc/{hash}`: get voucher token metadata
+// - `voucher/ibc/{hash}/balance/{addr}`: get a voucher balance for an address

--- a/gno.land/r/aib/ibc/core/render.gno
+++ b/gno.land/r/aib/ibc/core/render.gno
@@ -42,7 +42,7 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	out.WriteString("# IBC core\n\n")
 	out.WriteString("IBC v2 core state and query endpoints.\n\n")
 	out.WriteString("## Dashboard\n\n")
-	out.WriteString(ufmt.Sprintf("- Registered apps: `%d`\n", countRegisteredApps()))
+	out.WriteString(ufmt.Sprintf("- Registered apps: `%d`\n", len(store.routes)))
 	out.WriteString(ufmt.Sprintf("- Clients: `%d`\n\n", store.clientByID.Size()))
 	out.WriteString("## Endpoints\n\n")
 	out.WriteString("- [`apps`](/r/aib/ibc/core:apps): list registered IBC applications\n")
@@ -379,12 +379,4 @@ func nodeError(msg string, args ...any) *json.Node {
 	return json.ObjectNode("", map[string]*json.Node{
 		"error": json.StringNode("", ufmt.Sprintf(msg, args...)),
 	})
-}
-
-func countRegisteredApps() int {
-	var count int
-	for range store.routes {
-		count++
-	}
-	return count
 }

--- a/gno.land/r/aib/ibc/core/render.gno
+++ b/gno.land/r/aib/ibc/core/render.gno
@@ -59,7 +59,19 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	out.WriteString("- `clients/{id}/packet_acknowledgements`: list packet acknowledgements (`?page`, `?limit`)\n")
 	out.WriteString("- `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence\n")
 	out.WriteString("- `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt\n\n")
-	out.WriteString("Start with [`clients`](/r/aib/ibc/core:clients) to discover a client ID.\n")
+	out.WriteString("## Known clients\n\n")
+	if store.clientByID.Size() == 0 {
+		out.WriteString("No clients yet. Create one, then refresh this page.\n")
+	} else {
+		store.clientByID.IterateByOffset(0, store.clientByID.Size(), func(_ string, v any) bool {
+			c := v.(*client)
+			out.WriteString(ufmt.Sprintf(
+				"- `%s`: [details](/r/aib/ibc/core:clients/%s) | [status](/r/aib/ibc/core:clients/%s/status) | [consensus states](/r/aib/ibc/core:clients/%s/consensus_states) | [next sequence](/r/aib/ibc/core:clients/%s/next_sequence_send) | [commitments](/r/aib/ibc/core:clients/%s/packet_commitments) | [receipts](/r/aib/ibc/core:clients/%s/packet_receipts) | [acks](/r/aib/ibc/core:clients/%s/packet_acknowledgements)\n",
+				c.id, c.id, c.id, c.id, c.id, c.id, c.id, c.id,
+			))
+			return false
+		})
+	}
 	w.Write(out.String())
 }
 

--- a/gno.land/r/aib/ibc/core/render.gno
+++ b/gno.land/r/aib/ibc/core/render.gno
@@ -41,10 +41,49 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	var out strings.Builder
 	out.WriteString("# IBC core\n\n")
 	out.WriteString("IBC v2 core state and query endpoints.\n\n")
-	out.WriteString("## Dashboard\n\n")
-	out.WriteString(ufmt.Sprintf("- Registered apps: `%d`\n", len(store.routes)))
-	out.WriteString(ufmt.Sprintf("- Clients: `%d`\n\n", store.clientByID.Size()))
-	out.WriteString("## Endpoints\n\n")
+	out.WriteString(ufmt.Sprintf("## Clients (%d)\n\n", store.clientByID.Size()))
+	if store.clientByID.Size() > 0 {
+		out.WriteString("| Client | St. | Creator | Cpty | Height | CS | Seq | Cmts | Rcpts | Acks |\n")
+		out.WriteString("|--------|-----|---------|------|--------|----|-----|------|-------|------|\n")
+		store.clientByID.IterateByOffset(0, store.clientByID.Size(), func(_ string, v any) bool {
+			c := v.(*client)
+			var nConsStates int
+			switch c.typ {
+			case lightclient.Tendermint:
+				lc := c.lightClient.(*tendermint.TMLightClient)
+				nConsStates = lc.ConsensusStateByHeight.Size()
+			}
+			out.WriteString(ufmt.Sprintf(
+				"| [`%s`](/r/aib/ibc/core:clients/%s) | [%s](/r/aib/ibc/core:clients/%s/status) | %s | %s | [%s](/r/aib/ibc/core:clients/%s/consensus_states/%d/%d) | [%d](/r/aib/ibc/core:clients/%s/consensus_states) | [%d](/r/aib/ibc/core:clients/%s/next_sequence_send) | [%d](/r/aib/ibc/core:clients/%s/packet_commitments) | [%d](/r/aib/ibc/core:clients/%s/packet_receipts) | [%d](/r/aib/ibc/core:clients/%s/packet_acknowledgements) |\n",
+				c.id, c.id,
+				c.lightClient.Status(), c.id,
+				renderAddr(c.creator),
+				c.counterpartyClientID,
+				c.lightClient.LatestHeight().String(), c.id, c.lightClient.LatestHeight().RevisionNumber, c.lightClient.LatestHeight().RevisionHeight,
+				nConsStates, c.id,
+				int64(c.sendSeq)+1, c.id,
+				c.packetCommitmentsBySeq.Size(), c.id,
+				c.packetReceiptsBySeq.Size(), c.id,
+				c.packetAcknowledgementsBySeq.Size(), c.id,
+			))
+			return false
+		})
+		out.WriteString("\n")
+	} else {
+		out.WriteString("No clients yet.\n\n")
+	}
+	out.WriteString(ufmt.Sprintf("## Apps (%d)\n\n", len(store.routes)))
+	if len(store.routes) > 0 {
+		out.WriteString("| Port | Pkg | Addr |\n")
+		out.WriteString("|------|-----|------|\n")
+		for port, app := range store.routes {
+			out.WriteString(ufmt.Sprintf("| %s | %s | %s |\n", port, renderPkgPath(app.pkgPath), renderAddr(app.address)))
+		}
+		out.WriteString("\n")
+	} else {
+		out.WriteString("No apps registered yet.\n\n")
+	}
+	out.WriteString("## JSON endpoints\n\n")
 	out.WriteString("- [`apps`](/r/aib/ibc/core:apps): list registered IBC applications\n")
 	out.WriteString("- [`clients`](/r/aib/ibc/core:clients): list clients (`?page`, `?limit`)\n")
 	out.WriteString("- `clients/{id}`: get client details\n")
@@ -59,19 +98,6 @@ func renderHome(w *mux.ResponseWriter, r *mux.Request) {
 	out.WriteString("- `clients/{id}/packet_acknowledgements`: list packet acknowledgements (`?page`, `?limit`)\n")
 	out.WriteString("- `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence\n")
 	out.WriteString("- `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt\n\n")
-	out.WriteString("## Known clients\n\n")
-	if store.clientByID.Size() == 0 {
-		out.WriteString("No clients yet. Create one, then refresh this page.\n")
-	} else {
-		store.clientByID.IterateByOffset(0, store.clientByID.Size(), func(_ string, v any) bool {
-			c := v.(*client)
-			out.WriteString(ufmt.Sprintf(
-				"- `%s`: [details](/r/aib/ibc/core:clients/%s) | [status](/r/aib/ibc/core:clients/%s/status) | [consensus states](/r/aib/ibc/core:clients/%s/consensus_states) | [next sequence](/r/aib/ibc/core:clients/%s/next_sequence_send) | [commitments](/r/aib/ibc/core:clients/%s/packet_commitments) | [receipts](/r/aib/ibc/core:clients/%s/packet_receipts) | [acks](/r/aib/ibc/core:clients/%s/packet_acknowledgements)\n",
-				c.id, c.id, c.id, c.id, c.id, c.id, c.id, c.id,
-			))
-			return false
-		})
-	}
 	w.Write(out.String())
 }
 
@@ -335,6 +361,23 @@ func renderConsensusState(height types.Height, cs *tendermint.ConsensusState) *j
 		"root":                 json.StringNode("", base64.StdEncoding.EncodeToString(cs.Root.Hash)),
 		"next_validators_hash": json.StringNode("", base64.StdEncoding.EncodeToString(cs.NextValidatorsHash)),
 	})
+}
+
+func renderPkgPath(path string) string {
+	const prefix = "gno.land"
+	if strings.HasPrefix(path, prefix) {
+		return ufmt.Sprintf("[`%s`](%s)", path, path[len(prefix):])
+	}
+	return "`" + path + "`"
+}
+
+func renderAddr(addr address) string {
+	s := addr.String()
+	short := s
+	if len(s) > 10 {
+		short = s[:6] + "…" + s[len(s)-4:]
+	}
+	return ufmt.Sprintf("[%s](/u/%s)", short, s)
 }
 
 func renderHeight(h types.Height) *json.Node {

--- a/gno.land/r/aib/ibc/core/render.gno
+++ b/gno.land/r/aib/ibc/core/render.gno
@@ -38,8 +38,29 @@ func Render(path string) string {
 }
 
 func renderHome(w *mux.ResponseWriter, r *mux.Request) {
-	// TODO list available endpoints ?
-	w.Write(`["Hello IBC!"]`)
+	var out strings.Builder
+	out.WriteString("# IBC core\n\n")
+	out.WriteString("IBC v2 core state and query endpoints.\n\n")
+	out.WriteString("## Dashboard\n\n")
+	out.WriteString(ufmt.Sprintf("- Registered apps: `%d`\n", countRegisteredApps()))
+	out.WriteString(ufmt.Sprintf("- Clients: `%d`\n\n", store.clientByID.Size()))
+	out.WriteString("## Endpoints\n\n")
+	out.WriteString("- [`apps`](/r/aib/ibc/core:apps): list registered IBC applications\n")
+	out.WriteString("- [`clients`](/r/aib/ibc/core:clients): list clients (`?page`, `?limit`)\n")
+	out.WriteString("- `clients/{id}`: get client details\n")
+	out.WriteString("- `clients/{id}/status`: get client status\n")
+	out.WriteString("- `clients/{id}/consensus_states`: list client consensus states (`?page`, `?limit`)\n")
+	out.WriteString("- `clients/{id}/consensus_states/{revision_number}/{revision_height}`: get a consensus state by height\n")
+	out.WriteString("- `clients/{id}/next_sequence_send`: get the next packet sequence to send\n")
+	out.WriteString("- `clients/{id}/packet_commitments`: list packet commitments (`?page`, `?limit`)\n")
+	out.WriteString("- `clients/{id}/packet_commitments/{sequence}`: get a packet commitment by sequence\n")
+	out.WriteString("- `clients/{id}/packet_receipts`: list packet receipts (`?page`, `?limit`)\n")
+	out.WriteString("- `clients/{id}/packet_receipts/{sequence}`: get a packet receipt by sequence\n")
+	out.WriteString("- `clients/{id}/packet_acknowledgements`: list packet acknowledgements (`?page`, `?limit`)\n")
+	out.WriteString("- `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence\n")
+	out.WriteString("- `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt\n\n")
+	out.WriteString("Start with [`clients`](/r/aib/ibc/core:clients) to discover a client ID.\n")
+	w.Write(out.String())
 }
 
 func renderApps(w *mux.ResponseWriter, r *mux.Request) {
@@ -346,4 +367,12 @@ func nodeError(msg string, args ...any) *json.Node {
 	return json.ObjectNode("", map[string]*json.Node{
 		"error": json.StringNode("", ufmt.Sprintf(msg, args...)),
 	})
+}
+
+func countRegisteredApps() int {
+	var count int
+	for range store.routes {
+		count++
+	}
+	return count
 }

--- a/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
@@ -26,12 +26,17 @@ func main() {
 //
 // IBC v2 core state and query endpoints.
 //
-// ## Dashboard
+// ## Clients (1)
 //
-// - Registered apps: `0`
-// - Clients: `1`
+// | Client | St. | Creator | Cpty | Height | CS | Seq | Cmts | Rcpts | Acks |
+// |--------|-----|---------|------|--------|----|-----|------|-------|------|
+// | [`07-tendermint-1`](/r/aib/ibc/core:clients/07-tendermint-1) | [Active](/r/aib/ibc/core:clients/07-tendermint-1/status) | [g1wymu…yrsm](/u/g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm) |  | [2/2](/r/aib/ibc/core:clients/07-tendermint-1/consensus_states/2/2) | [1](/r/aib/ibc/core:clients/07-tendermint-1/consensus_states) | [1](/r/aib/ibc/core:clients/07-tendermint-1/next_sequence_send) | [0](/r/aib/ibc/core:clients/07-tendermint-1/packet_commitments) | [0](/r/aib/ibc/core:clients/07-tendermint-1/packet_receipts) | [0](/r/aib/ibc/core:clients/07-tendermint-1/packet_acknowledgements) |
 //
-// ## Endpoints
+// ## Apps (0)
+//
+// No apps registered yet.
+//
+// ## JSON endpoints
 //
 // - [`apps`](/r/aib/ibc/core:apps): list registered IBC applications
 // - [`clients`](/r/aib/ibc/core:clients): list clients (`?page`, `?limit`)
@@ -47,7 +52,3 @@ func main() {
 // - `clients/{id}/packet_acknowledgements`: list packet acknowledgements (`?page`, `?limit`)
 // - `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence
 // - `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt
-//
-// ## Known clients
-//
-// - `07-tendermint-1`: [details](/r/aib/ibc/core:clients/07-tendermint-1) | [status](/r/aib/ibc/core:clients/07-tendermint-1/status) | [consensus states](/r/aib/ibc/core:clients/07-tendermint-1/consensus_states) | [next sequence](/r/aib/ibc/core:clients/07-tendermint-1/next_sequence_send) | [commitments](/r/aib/ibc/core:clients/07-tendermint-1/packet_commitments) | [receipts](/r/aib/ibc/core:clients/07-tendermint-1/packet_receipts) | [acks](/r/aib/ibc/core:clients/07-tendermint-1/packet_acknowledgements)

--- a/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+func main() {
+	var (
+		chainID        = "chain-id-2"
+		clientState    = tmtesting.NewClientState(chainID, types.NewHeight(2, 2))
+		apphash        = tmtesting.Hash("apphash")
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	core.CreateClient(cross, clientState, consensusState)
+
+	println(core.Render(""))
+}
+
+// Output:
+// # IBC core
+//
+// IBC v2 core state and query endpoints.
+//
+// ## Dashboard
+//
+// - Registered apps: `0`
+// - Clients: `1`
+//
+// ## Endpoints
+//
+// - [`apps`](/r/aib/ibc/core:apps): list registered IBC applications
+// - [`clients`](/r/aib/ibc/core:clients): list clients (`?page`, `?limit`)
+// - `clients/{id}`: get client details
+// - `clients/{id}/status`: get client status
+// - `clients/{id}/consensus_states`: list client consensus states (`?page`, `?limit`)
+// - `clients/{id}/consensus_states/{revision_number}/{revision_height}`: get a consensus state by height
+// - `clients/{id}/next_sequence_send`: get the next packet sequence to send
+// - `clients/{id}/packet_commitments`: list packet commitments (`?page`, `?limit`)
+// - `clients/{id}/packet_commitments/{sequence}`: get a packet commitment by sequence
+// - `clients/{id}/packet_receipts`: list packet receipts (`?page`, `?limit`)
+// - `clients/{id}/packet_receipts/{sequence}`: get a packet receipt by sequence
+// - `clients/{id}/packet_acknowledgements`: list packet acknowledgements (`?page`, `?limit`)
+// - `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence
+// - `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt
+//
+// Start with [`clients`](/r/aib/ibc/core:clients) to discover a client ID.

--- a/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z0a_render_home_filetest.gno
@@ -48,4 +48,6 @@ func main() {
 // - `clients/{id}/packet_acknowledgements/{sequence}`: get a packet acknowledgement by sequence
 // - `clients/{id}/unreceived_packets?sequences=1,2,3`: return sequences without a local packet receipt
 //
-// Start with [`clients`](/r/aib/ibc/core:clients) to discover a client ID.
+// ## Known clients
+//
+// - `07-tendermint-1`: [details](/r/aib/ibc/core:clients/07-tendermint-1) | [status](/r/aib/ibc/core:clients/07-tendermint-1/status) | [consensus states](/r/aib/ibc/core:clients/07-tendermint-1/consensus_states) | [next sequence](/r/aib/ibc/core:clients/07-tendermint-1/next_sequence_send) | [commitments](/r/aib/ibc/core:clients/07-tendermint-1/packet_commitments) | [receipts](/r/aib/ibc/core:clients/07-tendermint-1/packet_receipts) | [acks](/r/aib/ibc/core:clients/07-tendermint-1/packet_acknowledgements)


### PR DESCRIPTION
close #30

## Summary

Adds useful default render output for the IBC home pages instead of the current placeholder responses.

### What changed

- added a structured home render for `gno.land/r/aib/ibc/core`
- added a structured home render for `gno.land/r/aib/ibc/apps/transfer`
- included lightweight dashboard data on each page
- listed the available render/query endpoints on each home page
- added filetests covering the new home render output