### PR TITLE
feat(core): implement RecoverClient

### DIFF
--- a/gno.land/p/aib/ibc/lightclient/lightclient.gno
+++ b/gno.land/p/aib/ibc/lightclient/lightclient.gno
@@ -99,9 +99,10 @@ type Interface interface {
 	TimestampAtHeight(types.Height) (uint64, error)
 
 	// RecoverClient must verify that the provided substitute may be used to
-	// update the subject client.  The light client module must set the updated
-	// client and consensus states within the clientStore for the subject client.
-	RecoverClient(substituteClientID string) error
+	// recover the subject (receiver) client, and copy the substitute's updated
+	// client and consensus state into the subject. The caller is responsible
+	// for verifying Status() on both sides and authorization beforehand.
+	RecoverClient(substitute Interface) error
 
 	// Upgrade functions NOTE: proof heights are not included as upgrade to a new
 	// revision is expected to pass only on the last height committed by the

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
@@ -266,8 +266,8 @@ func (tm *TMLightClient) RecoverClient(substitute lightclient.Interface) error {
 	if !ok {
 		return ufmt.Errorf("substitute client type mismatch: expected *TMLightClient, got %T", substitute)
 	}
-	if !isMatchingClientState(tm.ClientState, sub.ClientState) {
-		return errors.New("subject client state does not match substitute client state")
+	if field := mismatchingClientStateField(tm.ClientState, sub.ClientState); field != "" {
+		return ufmt.Errorf("subject and substitute client states differ on %s", field)
 	}
 	subLatest := sub.ClientState.LatestHeight
 	subConsState, found := sub.GetConsensusState(subLatest)
@@ -283,37 +283,38 @@ func (tm *TMLightClient) RecoverClient(substitute lightclient.Interface) error {
 	return nil
 }
 
-// isMatchingClientState returns true if the two client states share all
-// parameters that must not change during a client recovery. ChainID,
+// mismatchingClientStateField returns the name of the first client-state field
+// that differs between subject and substitute, or an empty string if all
+// parameters that must not change during a client recovery match. ChainID,
 // LatestHeight, FrozenHeight and TrustingPeriod are allowed to differ — the
 // substitute's TrustingPeriod is adopted by the subject.
-func isMatchingClientState(subject, substitute *ClientState) bool {
+func mismatchingClientStateField(subject, substitute *ClientState) string {
 	if subject.TrustLevel != substitute.TrustLevel {
-		return false
+		return "TrustLevel"
 	}
 	if subject.UnbondingPeriod != substitute.UnbondingPeriod {
-		return false
+		return "UnbondingPeriod"
 	}
 	if subject.MaxClockDrift != substitute.MaxClockDrift {
-		return false
+		return "MaxClockDrift"
 	}
 	if len(subject.ProofSpecs) != len(substitute.ProofSpecs) {
-		return false
+		return "ProofSpecs"
 	}
 	for i := range subject.ProofSpecs {
 		if !subject.ProofSpecs[i].Equal(substitute.ProofSpecs[i]) {
-			return false
+			return "ProofSpecs"
 		}
 	}
 	if len(subject.UpgradePath) != len(substitute.UpgradePath) {
-		return false
+		return "UpgradePath"
 	}
 	for i := range subject.UpgradePath {
 		if subject.UpgradePath[i] != substitute.UpgradePath[i] {
-			return false
+			return "UpgradePath"
 		}
 	}
-	return true
+	return ""
 }
 
 // Implements lightclient.Interface

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
@@ -262,6 +262,9 @@ func (tm *TMLightClient) TimestampAtHeight(height types.Height) (uint64, error) 
 // resetting FrozenHeight. The substitute and subject client states must match
 // in TrustLevel, UnbondingPeriod, MaxClockDrift, ProofSpecs and UpgradePath.
 func (tm *TMLightClient) RecoverClient(substitute lightclient.Interface) error {
+	if substitute == nil {
+		return errors.New("substitute must not be nil")
+	}
 	sub, ok := substitute.(*TMLightClient)
 	if !ok {
 		return ufmt.Errorf("substitute client type mismatch: expected *TMLightClient, got %T", substitute)

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint.gno
@@ -254,10 +254,66 @@ func (tm *TMLightClient) TimestampAtHeight(height types.Height) (uint64, error) 
 	return uint64(cs.Timestamp.Unix()), nil
 }
 
-// Implements lightclient.Interface
-func (tm *TMLightClient) RecoverClient(substituteClientID string) error {
-	// TODO
-	panic("not implemented")
+// Implements lightclient.Interface.
+//
+// RecoverClient copies the substitute's consensus state at its latest height
+// into the subject (tm), updates the subject's ChainID, LatestHeight and
+// TrustingPeriod to match the substitute, and un-freezes the subject by
+// resetting FrozenHeight. The substitute and subject client states must match
+// in TrustLevel, UnbondingPeriod, MaxClockDrift, ProofSpecs and UpgradePath.
+func (tm *TMLightClient) RecoverClient(substitute lightclient.Interface) error {
+	sub, ok := substitute.(*TMLightClient)
+	if !ok {
+		return ufmt.Errorf("substitute client type mismatch: expected *TMLightClient, got %T", substitute)
+	}
+	if !isMatchingClientState(tm.ClientState, sub.ClientState) {
+		return errors.New("subject client state does not match substitute client state")
+	}
+	subLatest := sub.ClientState.LatestHeight
+	subConsState, found := sub.GetConsensusState(subLatest)
+	if !found {
+		return ufmt.Errorf("substitute consensus state not found at height %s", subLatest)
+	}
+
+	tm.ClientState.ChainID = sub.ClientState.ChainID
+	tm.ClientState.LatestHeight = subLatest
+	tm.ClientState.TrustingPeriod = sub.ClientState.TrustingPeriod
+	tm.ClientState.FrozenHeight = types.ZeroHeight()
+	tm.SetConsensusState(subLatest, subConsState)
+	return nil
+}
+
+// isMatchingClientState returns true if the two client states share all
+// parameters that must not change during a client recovery. ChainID,
+// LatestHeight, FrozenHeight and TrustingPeriod are allowed to differ — the
+// substitute's TrustingPeriod is adopted by the subject.
+func isMatchingClientState(subject, substitute *ClientState) bool {
+	if subject.TrustLevel != substitute.TrustLevel {
+		return false
+	}
+	if subject.UnbondingPeriod != substitute.UnbondingPeriod {
+		return false
+	}
+	if subject.MaxClockDrift != substitute.MaxClockDrift {
+		return false
+	}
+	if len(subject.ProofSpecs) != len(substitute.ProofSpecs) {
+		return false
+	}
+	for i := range subject.ProofSpecs {
+		if !subject.ProofSpecs[i].Equal(substitute.ProofSpecs[i]) {
+			return false
+		}
+	}
+	if len(subject.UpgradePath) != len(substitute.UpgradePath) {
+		return false
+	}
+	for i := range subject.UpgradePath {
+		if subject.UpgradePath[i] != substitute.UpgradePath[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Implements lightclient.Interface

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
@@ -4,9 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"gno.land/p/aib/ibc/lightclient"
 	"gno.land/p/aib/ibc/lightclient/tendermint"
 	"gno.land/p/aib/ibc/types"
 	"gno.land/p/aib/ics23"
+	"gno.land/p/nt/uassert/v0"
 	"gno.land/p/nt/urequire/v0"
 )
 
@@ -71,4 +73,110 @@ func TestGetNeighboringConsensusStates(t *testing.T) {
 	nextCs49, ok := tm.GetNextConsensusState(height49)
 	urequire.True(t, nextCs49 == nil, "next consensus state exists after highest consensus state")
 	urequire.False(t, ok)
+}
+
+func TestRecoverClient(t *testing.T) {
+	newConsState := func(root string) *tendermint.ConsensusState {
+		return &tendermint.ConsensusState{
+			Timestamp:          time.Now().UTC(),
+			Root:               tendermint.NewMerkleRoot([]byte(root)),
+			NextValidatorsHash: []byte("nextVals"),
+		}
+	}
+	// Build two clients with matching immutable parameters, different chainIDs
+	// and different latest heights.
+	newSubject := func() *tendermint.TMLightClient {
+		tm := tendermint.NewTMLightClient()
+		cs := tendermint.NewClientState("subject-chain", tendermint.DefaultTrustLevel,
+			trustingPeriod, ubdPeriod, maxClockDrift, types.NewHeight(0, 5),
+			ics23.GetSDKProofSpecs(), upgradePath)
+		urequire.NoError(t, tm.Initialize(*cs, *newConsState("subject-root")))
+		// Freeze the subject so its status becomes Frozen (for realism; not
+		// required by RecoverClient itself).
+		tm.ClientState.FrozenHeight = tendermint.FrozenHeight
+		return tm
+	}
+	newSubstitute := func() *tendermint.TMLightClient {
+		tm := tendermint.NewTMLightClient()
+		cs := tendermint.NewClientState("substitute-chain", tendermint.DefaultTrustLevel,
+			trustingPeriod, ubdPeriod, maxClockDrift, types.NewHeight(0, 10),
+			ics23.GetSDKProofSpecs(), upgradePath)
+		urequire.NoError(t, tm.Initialize(*cs, *newConsState("substitute-root")))
+		return tm
+	}
+
+	t.Run("success", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+
+		err := subject.RecoverClient(substitute)
+		urequire.NoError(t, err)
+
+		uassert.Equal(t, "substitute-chain", subject.ClientState.ChainID)
+		uassert.True(t, subject.ClientState.LatestHeight.EQ(types.NewHeight(0, 10)))
+		uassert.True(t, subject.ClientState.FrozenHeight.IsZero())
+		// Substitute consensus state at height (0,10) must have been copied.
+		cs, found := subject.GetConsensusState(types.NewHeight(0, 10))
+		urequire.True(t, found, "consensus state at substitute latest height not copied")
+		uassert.Equal(t, "substitute-root", string(cs.Root.Hash))
+	})
+
+	t.Run("failure: substitute not a *TMLightClient", func(t *testing.T) {
+		subject := newSubject()
+
+		err := subject.RecoverClient(nil)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "substitute client type mismatch")
+	})
+
+	t.Run("success: substitute TrustingPeriod is adopted", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.TrustingPeriod = trustingPeriod + time.Hour
+
+		err := subject.RecoverClient(substitute)
+		urequire.NoError(t, err)
+		uassert.Equal(t, int64(trustingPeriod+time.Hour), int64(subject.ClientState.TrustingPeriod))
+	})
+
+	t.Run("failure: mismatching max clock drift", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.MaxClockDrift = maxClockDrift + time.Second
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "does not match substitute client state")
+	})
+
+	t.Run("failure: mismatching trust level", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.TrustLevel = tendermint.NewFraction(2, 3)
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "does not match substitute client state")
+	})
+
+	t.Run("failure: missing consensus state at substitute latest height", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		// Drop the consensus state that Initialize stored.
+		substitute.ConsensusStateByHeight.Remove(substitute.ClientState.LatestHeight.StringNatSort())
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "substitute consensus state not found")
+	})
+
+	// Assertion that interface conformance holds when calling through the
+	// lightclient.Interface type (catches future signature drift).
+	t.Run("success via Interface", func(t *testing.T) {
+		subject := newSubject()
+		var substitute lightclient.Interface = newSubstitute()
+
+		err := subject.RecoverClient(substitute)
+		urequire.NoError(t, err)
+	})
 }

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
@@ -146,7 +146,7 @@ func TestRecoverClient(t *testing.T) {
 
 		err := subject.RecoverClient(substitute)
 		urequire.Error(t, err)
-		urequire.ErrorContains(t, err, "does not match substitute client state")
+		urequire.ErrorContains(t, err, "differ on MaxClockDrift")
 	})
 
 	t.Run("failure: mismatching trust level", func(t *testing.T) {
@@ -156,7 +156,37 @@ func TestRecoverClient(t *testing.T) {
 
 		err := subject.RecoverClient(substitute)
 		urequire.Error(t, err)
-		urequire.ErrorContains(t, err, "does not match substitute client state")
+		urequire.ErrorContains(t, err, "differ on TrustLevel")
+	})
+
+	t.Run("failure: mismatching unbonding period", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.UnbondingPeriod = ubdPeriod + time.Hour
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "differ on UnbondingPeriod")
+	})
+
+	t.Run("failure: mismatching proof specs", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.ProofSpecs = substitute.ClientState.ProofSpecs[:1]
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "differ on ProofSpecs")
+	})
+
+	t.Run("failure: mismatching upgrade path", func(t *testing.T) {
+		subject := newSubject()
+		substitute := newSubstitute()
+		substitute.ClientState.UpgradePath = []string{"otherUpgrade"}
+
+		err := subject.RecoverClient(substitute)
+		urequire.Error(t, err)
+		urequire.ErrorContains(t, err, "differ on UpgradePath")
 	})
 
 	t.Run("failure: missing consensus state at substitute latest height", func(t *testing.T) {

--- a/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
+++ b/gno.land/p/aib/ibc/lightclient/tendermint/tendermint_test.gno
@@ -121,12 +121,12 @@ func TestRecoverClient(t *testing.T) {
 		uassert.Equal(t, "substitute-root", string(cs.Root.Hash))
 	})
 
-	t.Run("failure: substitute not a *TMLightClient", func(t *testing.T) {
+	t.Run("failure: substitute is nil", func(t *testing.T) {
 		subject := newSubject()
 
 		err := subject.RecoverClient(nil)
 		urequire.Error(t, err)
-		urequire.ErrorContains(t, err, "substitute client type mismatch")
+		urequire.ErrorContains(t, err, "substitute must not be nil")
 	})
 
 	t.Run("success: substitute TrustingPeriod is adopted", func(t *testing.T) {

--- a/gno.land/p/aib/ibc/types/events.gno
+++ b/gno.land/p/aib/ibc/types/events.gno
@@ -10,13 +10,14 @@ const (
 	EventTypeScheduleIBCSoftwareUpgrade = "schedule_ibc_software_upgrade"
 	EventTypeUpgradeChain               = "upgrade_chain"
 
-	AttributeKeyClientID          = "client_id"
-	AttributeKeySubjectClientID   = "subject_client_id"
-	AttributeKeyClientType        = "client_type"
-	AttributeKeyConsensusHeights  = "consensus_heights"
-	AttributeKeyUpgradeStore      = "upgrade_store"
-	AttributeKeyUpgradePlanHeight = "upgrade_plan_height"
-	AttributeKeyUpgradePlanTitle  = "title"
+	AttributeKeyClientID           = "client_id"
+	AttributeKeySubjectClientID    = "subject_client_id"
+	AttributeKeySubstituteClientID = "substitute_client_id"
+	AttributeKeyClientType         = "client_type"
+	AttributeKeyConsensusHeights   = "consensus_heights"
+	AttributeKeyUpgradeStore       = "upgrade_store"
+	AttributeKeyUpgradePlanHeight  = "upgrade_plan_height"
+	AttributeKeyUpgradePlanTitle   = "title"
 )
 
 // IBC core events

--- a/gno.land/p/aib/ics23/proof.gno
+++ b/gno.land/p/aib/ics23/proof.gno
@@ -542,6 +542,60 @@ func orderFromPadding(spec *InnerSpec, inner *InnerOp) (int32, error) {
 	return 0, errors.New("cannot find any valid spacing for this node")
 }
 
+// Equal returns true if the two ProofSpec instances are deeply equal across
+// every field. Use this when you need a strict content comparison (e.g. to
+// detect attempts at substituting a different spec for an existing client).
+// For the looser, "same shape" comparison historically used to route proof
+// verification through IavlSpec/TendermintSpec, use SpecEquals instead.
+func (p *ProofSpec) Equal(other *ProofSpec) bool {
+	if p == nil || other == nil {
+		return p == other
+	}
+	if p.MaxDepth != other.MaxDepth ||
+		p.MinDepth != other.MinDepth ||
+		p.PrehashKeyBeforeComparison != other.PrehashKeyBeforeComparison {
+		return false
+	}
+	if !p.LeafSpec.Equal(other.LeafSpec) {
+		return false
+	}
+	return p.InnerSpec.Equal(other.InnerSpec)
+}
+
+// Equal returns true if the two LeafOp instances are deeply equal.
+func (p *LeafOp) Equal(other *LeafOp) bool {
+	if p == nil || other == nil {
+		return p == other
+	}
+	return p.Hash == other.Hash &&
+		p.PrehashKey == other.PrehashKey &&
+		p.PrehashValue == other.PrehashValue &&
+		p.Length == other.Length &&
+		bytes.Equal(p.Prefix, other.Prefix)
+}
+
+// Equal returns true if the two InnerSpec instances are deeply equal.
+func (p *InnerSpec) Equal(other *InnerSpec) bool {
+	if p == nil || other == nil {
+		return p == other
+	}
+	if p.ChildSize != other.ChildSize ||
+		p.MinPrefixLength != other.MinPrefixLength ||
+		p.MaxPrefixLength != other.MaxPrefixLength ||
+		p.Hash != other.Hash {
+		return false
+	}
+	if len(p.ChildOrder) != len(other.ChildOrder) {
+		return false
+	}
+	for i := range p.ChildOrder {
+		if p.ChildOrder[i] != other.ChildOrder[i] {
+			return false
+		}
+	}
+	return bytes.Equal(p.EmptyChild, other.EmptyChild)
+}
+
 // over-declares equality, which we consider fine for now.
 func (p *ProofSpec) SpecEquals(spec *ProofSpec) bool {
 	// 1. Compare LeafSpecs values.

--- a/gno.land/p/aib/ics23/proof.gno
+++ b/gno.land/p/aib/ics23/proof.gno
@@ -596,7 +596,12 @@ func (p *InnerSpec) Equal(other *InnerSpec) bool {
 	return bytes.Equal(p.EmptyChild, other.EmptyChild)
 }
 
-// over-declares equality, which we consider fine for now.
+// SpecEquals returns true if two ProofSpec instances match on the subset of
+// fields that matter for routing proof verification through a known spec
+// (IavlSpec/TendermintSpec). It intentionally ignores MaxDepth/MinDepth,
+// LeafOp.Prefix, ChildOrder contents, and InnerSpec.EmptyChild — it
+// over-declares equality, which we consider fine for that use case.
+// Use Equal for strict field-by-field comparison (e.g. RecoverClient).
 func (p *ProofSpec) SpecEquals(spec *ProofSpec) bool {
 	// 1. Compare LeafSpecs values.
 	switch {

--- a/gno.land/p/aib/ics23/proof_test.gno
+++ b/gno.land/p/aib/ics23/proof_test.gno
@@ -1,0 +1,112 @@
+package ics23_test
+
+import (
+	"testing"
+
+	"gno.land/p/aib/ics23"
+	"gno.land/p/nt/uassert/v0"
+)
+
+func TestProofSpecEqual(t *testing.T) {
+	newLeaf := func() *ics23.LeafOp {
+		return &ics23.LeafOp{
+			Prefix:       []byte{0},
+			PrehashKey:   ics23.HashOp_NO_HASH,
+			Hash:         ics23.HashOp_SHA256,
+			PrehashValue: ics23.HashOp_SHA256,
+			Length:       ics23.LengthOp_VAR_PROTO,
+		}
+	}
+	newInner := func() *ics23.InnerSpec {
+		return &ics23.InnerSpec{
+			ChildOrder:      []int32{0, 1},
+			MinPrefixLength: 4,
+			MaxPrefixLength: 12,
+			ChildSize:       33,
+			EmptyChild:      nil,
+			Hash:            ics23.HashOp_SHA256,
+		}
+	}
+	newSpec := func() *ics23.ProofSpec {
+		return &ics23.ProofSpec{
+			LeafSpec:                   newLeaf(),
+			InnerSpec:                  newInner(),
+			MaxDepth:                   0,
+			MinDepth:                   0,
+			PrehashKeyBeforeComparison: false,
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		malleate func(a, b *ics23.ProofSpec)
+		expEqual bool
+	}{
+		{"equal — same fresh spec", func(a, b *ics23.ProofSpec) {}, true},
+		{"equal — same as well-known IavlSpec", func(a, b *ics23.ProofSpec) {
+			*a = *ics23.IavlSpec()
+			*b = *ics23.IavlSpec()
+		}, true},
+		{"differ — MaxDepth", func(a, b *ics23.ProofSpec) { b.MaxDepth = 10 }, false},
+		{"differ — MinDepth", func(a, b *ics23.ProofSpec) { b.MinDepth = 1 }, false},
+		{"differ — PrehashKeyBeforeComparison", func(a, b *ics23.ProofSpec) { b.PrehashKeyBeforeComparison = true }, false},
+		{"differ — LeafSpec.Hash", func(a, b *ics23.ProofSpec) { b.LeafSpec.Hash = ics23.HashOp_NO_HASH }, false},
+		{"differ — LeafSpec.PrehashKey", func(a, b *ics23.ProofSpec) { b.LeafSpec.PrehashKey = ics23.HashOp_SHA256 }, false},
+		{"differ — LeafSpec.PrehashValue", func(a, b *ics23.ProofSpec) { b.LeafSpec.PrehashValue = ics23.HashOp_NO_HASH }, false},
+		{"differ — LeafSpec.Length", func(a, b *ics23.ProofSpec) { b.LeafSpec.Length = ics23.LengthOp_NO_PREFIX }, false},
+		{"differ — LeafSpec.Prefix", func(a, b *ics23.ProofSpec) { b.LeafSpec.Prefix = []byte{1} }, false},
+		{"differ — LeafSpec nil vs non-nil", func(a, b *ics23.ProofSpec) { b.LeafSpec = nil }, false},
+		{"differ — InnerSpec.ChildSize", func(a, b *ics23.ProofSpec) { b.InnerSpec.ChildSize = 32 }, false},
+		{"differ — InnerSpec.MinPrefixLength", func(a, b *ics23.ProofSpec) { b.InnerSpec.MinPrefixLength = 1 }, false},
+		{"differ — InnerSpec.MaxPrefixLength", func(a, b *ics23.ProofSpec) { b.InnerSpec.MaxPrefixLength = 99 }, false},
+		{"differ — InnerSpec.Hash", func(a, b *ics23.ProofSpec) { b.InnerSpec.Hash = ics23.HashOp_NO_HASH }, false},
+		{"differ — InnerSpec.ChildOrder length", func(a, b *ics23.ProofSpec) { b.InnerSpec.ChildOrder = []int32{0, 1, 2} }, false},
+		{"differ — InnerSpec.ChildOrder content", func(a, b *ics23.ProofSpec) { b.InnerSpec.ChildOrder = []int32{1, 0} }, false},
+		{"differ — InnerSpec.EmptyChild", func(a, b *ics23.ProofSpec) { b.InnerSpec.EmptyChild = []byte{0, 0, 0} }, false},
+		{"differ — InnerSpec nil vs non-nil", func(a, b *ics23.ProofSpec) { b.InnerSpec = nil }, false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, b := newSpec(), newSpec()
+			tc.malleate(a, b)
+			uassert.Equal(t, tc.expEqual, a.Equal(b), "a.Equal(b)")
+			// Equal must be symmetric.
+			uassert.Equal(t, tc.expEqual, b.Equal(a), "b.Equal(a)")
+		})
+	}
+}
+
+func TestProofSpecEqualNil(t *testing.T) {
+	spec := ics23.IavlSpec()
+
+	var nilSpec *ics23.ProofSpec
+	uassert.True(t, nilSpec.Equal(nil), "nil.Equal(nil) must be true")
+	uassert.False(t, spec.Equal(nil), "non-nil.Equal(nil) must be false")
+	uassert.False(t, nilSpec.Equal(spec), "nil.Equal(non-nil) must be false")
+}
+
+func TestLeafOpEqual(t *testing.T) {
+	var nilOp *ics23.LeafOp
+	uassert.True(t, nilOp.Equal(nil))
+
+	a := &ics23.LeafOp{Hash: ics23.HashOp_SHA256, Prefix: []byte{0x01}}
+	b := &ics23.LeafOp{Hash: ics23.HashOp_SHA256, Prefix: []byte{0x01}}
+	uassert.True(t, a.Equal(b))
+	uassert.False(t, a.Equal(nil))
+
+	b.Prefix = []byte{0x02}
+	uassert.False(t, a.Equal(b))
+}
+
+func TestInnerSpecEqual(t *testing.T) {
+	var nilSpec *ics23.InnerSpec
+	uassert.True(t, nilSpec.Equal(nil))
+
+	a := &ics23.InnerSpec{ChildOrder: []int32{0, 1}, ChildSize: 33, Hash: ics23.HashOp_SHA256}
+	b := &ics23.InnerSpec{ChildOrder: []int32{0, 1}, ChildSize: 33, Hash: ics23.HashOp_SHA256}
+	uassert.True(t, a.Equal(b))
+	uassert.False(t, a.Equal(nil))
+
+	b.ChildSize = 32
+	uassert.False(t, a.Equal(b))
+}

--- a/gno.land/r/aib/ibc/core/README.md
+++ b/gno.land/r/aib/ibc/core/README.md
@@ -142,3 +142,26 @@ Emitted event:
   }
 ]
 ```
+
+## RecoverClient
+
+See [`recover-client.md`](./recover-client.md) for the end-to-end flow and
+which parameters can be adjusted during recovery.
+
+Emitted event:
+```json
+{
+  "type": "recover_client",
+  "attrs": [
+    {
+      "key": "subject_client_id",
+      "value": "07-tendermint-1"
+    },
+    {
+      "key": "client_type",
+      "value": "07-tendermint"
+    }
+  ],
+  "pkg_path": "gno.land/r/aib/ibc/core"
+}
+```

--- a/gno.land/r/aib/ibc/core/README.md
+++ b/gno.land/r/aib/ibc/core/README.md
@@ -158,6 +158,10 @@ Emitted event:
       "value": "07-tendermint-1"
     },
     {
+      "key": "substitute_client_id",
+      "value": "07-tendermint-2"
+    },
+    {
       "key": "client_type",
       "value": "07-tendermint"
     }

--- a/gno.land/r/aib/ibc/core/client.gno
+++ b/gno.land/r/aib/ibc/core/client.gno
@@ -163,6 +163,7 @@ func RecoverClient(cur realm, subjectClientID, substituteClientID string) {
 	}
 	chain.Emit(types.EventTypeRecoverClient,
 		types.AttributeKeySubjectClientID, subject.id,
+		types.AttributeKeySubstituteClientID, substitute.id,
 		types.AttributeKeyClientType, subject.typ,
 	)
 }

--- a/gno.land/r/aib/ibc/core/client.gno
+++ b/gno.land/r/aib/ibc/core/client.gno
@@ -125,9 +125,44 @@ func UpgradeClient(cur realm, clientID string, clientState, consensusState, proo
 	panic("not implemented")
 }
 
-// RecoverClient recovers a frozen or expired client.
-// NOTE(tb): This must be a permissioned function called by a gov proposal.
-func RecoverClient(cur realm, clientID string) {
-	// TODO
-	panic("not implemented")
+// RecoverClient recovers a frozen or expired subject client using a healthy
+// substitute client that tracks the same counterparty chain.
+func RecoverClient(cur realm, subjectClientID, substituteClientID string) {
+	ensureAdminCaller()
+	if subjectClientID == substituteClientID {
+		panic("subject and substitute client IDs must differ")
+	}
+	subject := store.getClient(subjectClientID)
+	if subject == nil {
+		panic(ufmt.Sprintf("subject client %s not found", subjectClientID))
+	}
+	substitute := store.getClient(substituteClientID)
+	if substitute == nil {
+		panic(ufmt.Sprintf("substitute client %s not found", substituteClientID))
+	}
+	if subject.typ != substitute.typ {
+		panic(ufmt.Sprintf(
+			"subject client type %s does not match substitute client type %s",
+			subject.typ, substitute.typ,
+		))
+	}
+	if status := subject.lightClient.Status(); status != lightclient.Frozen && status != lightclient.Expired {
+		panic(ufmt.Sprintf(
+			"cannot recover subject client %s with status %s",
+			subject.id, status,
+		))
+	}
+	if status := substitute.lightClient.Status(); status != lightclient.Active {
+		panic(ufmt.Sprintf(
+			"substitute client %s must be Active, got %s",
+			substitute.id, status,
+		))
+	}
+	if err := subject.lightClient.RecoverClient(substitute.lightClient); err != nil {
+		panic(err)
+	}
+	chain.Emit(types.EventTypeRecoverClient,
+		types.AttributeKeySubjectClientID, subject.id,
+		types.AttributeKeyClientType, subject.typ,
+	)
 }

--- a/gno.land/r/aib/ibc/core/recover-client.md
+++ b/gno.land/r/aib/ibc/core/recover-client.md
@@ -52,7 +52,12 @@ The following are allowed to differ and are **adopted from the substitute** by
 the subject during recovery:
 
 - `ChainID` (typically the same, but the code supports a change — for example
-  a genesis-restart on a new chain ID tracking the same state)
+  a genesis-restart on a new chain ID tracking the same state). `ChainID` and
+  `LatestHeight` are always adopted together, so their revision numbers stay
+  aligned: `ClientState.ValidateBasic` requires
+  `LatestHeight.RevisionNumber == ParseChainID(ChainID)`, and since both sides
+  of that equality come from the substitute (which passed `ValidateBasic` at
+  `CreateClient`), the invariant is preserved on the subject post-recovery.
 - `LatestHeight`
 - `TrustingPeriod` — this is the parameter-tweaking knob: if the original
   `TrustingPeriod` was set too aggressively (and partly caused the expiry),

--- a/gno.land/r/aib/ibc/core/recover-client.md
+++ b/gno.land/r/aib/ibc/core/recover-client.md
@@ -1,0 +1,152 @@
+# RecoverClient
+
+`core.RecoverClient` is the governance escape hatch that revives a client that
+has become unusable — either **Frozen** (valid misbehaviour was submitted via
+`UpdateClient`) or **Expired** (no valid header was submitted within the
+`TrustingPeriod`) — by copying state from a healthy **substitute** client that
+tracks the same counterparty chain.
+
+```gno
+core.RecoverClient(cross, subjectClientID, substituteClientID string)
+```
+
+Only the admin can call it (see `admin.gno`). In the long run this is expected
+to be driven by a govDAO proposal callback (tracked in issue #36).
+
+## End-to-end flow
+
+### 1. A client becomes unusable
+
+- **Frozen**: a relayer submitted valid misbehaviour via `UpdateClient` (two
+  conflicting signed headers for the same chain). The client's `FrozenHeight`
+  becomes non-zero and `Status()` returns `Frozen`.
+- **Expired**: no valid header was submitted within `TrustingPeriod`, so
+  `Status()` returns `Expired` because the latest consensus state's timestamp
+  is too old.
+
+From this point `SendPacket`, `RecvPacket`, `Acknowledgement`, `Timeout` and
+`UpdateClient` all panic for this client. Any in-flight user packets are
+stuck, and any inbound packets cannot be acknowledged. Channels using this
+client are frozen on this side until the client is recovered.
+
+### 2. Off-chain coordination
+
+Stakeholders agree to recover rather than migrate to a brand-new client.
+Recovery is preferable because it preserves the client ID, packet
+commitments / receipts / acknowledgements, counterparty registration and
+channel state — users don't need to migrate anything.
+
+### 3. Create a substitute client
+
+A relayer calls `core.CreateClient` with a fresh, **Active** client targeting
+the *same counterparty chain*. The substitute must satisfy
+`isMatchingClientState` with the subject, i.e. these fields must match:
+
+- `TrustLevel`
+- `UnbondingPeriod`
+- `MaxClockDrift`
+- `ProofSpecs`
+- `UpgradePath`
+
+The following are allowed to differ and are **adopted from the substitute** by
+the subject during recovery:
+
+- `ChainID` (typically the same, but the code supports a change — for example
+  a genesis-restart on a new chain ID tracking the same state)
+- `LatestHeight`
+- `TrustingPeriod` — this is the parameter-tweaking knob: if the original
+  `TrustingPeriod` was set too aggressively (and partly caused the expiry),
+  governance can choose a larger value on the substitute and that new value is
+  copied into the subject. Same mechanism as ibc-go.
+- `FrozenHeight` (always reset to zero)
+
+### 4. (Optional) Fast-forward the substitute
+
+Relayers call `UpdateClient(substituteID, header)` until the substitute's
+`LatestHeight` is at the desired recovery height. The substitute must be
+`Active` at the moment recovery executes.
+
+### 5. Governance proposal
+
+A proposal asks to run:
+
+```gno
+core.RecoverClient(cross, subjectID, substituteID)
+```
+
+Currently gated by `ensureAdminCaller()`; once govDAO integration lands the
+proposal executor becomes the authorized caller.
+
+### 6. `RecoverClient` executes
+
+`r/aib/ibc/core/client.gno`:
+
+1. `ensureAdminCaller()`.
+2. Subject and substitute IDs must differ; both must resolve; `typ` must match.
+3. Subject status ∈ {`Frozen`, `Expired`}; substitute status must be `Active`.
+4. Delegates to `subject.lightClient.RecoverClient(substitute.lightClient)`.
+
+`p/aib/ibc/lightclient/tendermint/tendermint.gno`:
+
+1. Type-assert substitute to `*TMLightClient`.
+2. `isMatchingClientState` check.
+3. Fetch `substitute.GetConsensusState(substitute.LatestHeight)`.
+4. Copy into subject: `ChainID`, `LatestHeight`, `TrustingPeriod`; reset
+   `FrozenHeight`.
+5. Store the substitute's consensus state at the substitute's latest height in
+   the subject.
+
+### 7. Post-recovery state
+
+- Subject's `Status() == Active`. `UpdateClient`, packet verification, etc.
+  resume.
+- **Packet commitments, receipts, acknowledgements, `sendSeq`,
+  `counterpartyClientID`, `counterpartyMerklePrefix` are untouched** — that is
+  the point: channels keep working with their existing identifiers and
+  in-flight state.
+- Pre-recovery consensus states remain in the subject's tree but are below the
+  new `LatestHeight` and are not used to verify new packets.
+- The substitute client is **not** deleted and remains `Active`. It can be
+  reused for a future recovery or left idle.
+- `recover_client` event is emitted.
+
+### 8. Counterparty side (symmetric)
+
+If the counterparty chain's client tracking this chain is also Frozen/Expired
+(common when misbehaviour or a long halt affects both sides), the counterparty
+runs its own governance-level recovery. Packet relaying cannot resume on that
+path until both sides are `Active`.
+
+### 9. Relayer resumes
+
+Once both sides are `Active`, relayers submit headers via `UpdateClient` and
+the normal packet lifecycle resumes. No re-`RegisterCounterparty`, no new
+channel.
+
+## Changing parameters during recovery
+
+Because the substitute's `TrustingPeriod` and `ChainID` are adopted by the
+subject, creating the substitute is also the opportunity to adjust those
+parameters through the same governance action:
+
+- **Lengthening `TrustingPeriod`** to reduce the risk of future expiry — for
+  example after learning that the counterparty's block production is slower
+  than originally assumed.
+- **Adopting a new `ChainID`** after a counterparty genesis restart that kept
+  the same consensus state tree — the subject starts verifying headers signed
+  under the new chain ID without being migrated to a new client ID.
+
+Other parameters (`TrustLevel`, `UnbondingPeriod`, `MaxClockDrift`,
+`ProofSpecs`, `UpgradePath`) **cannot** be changed by recovery — the match
+check rejects the substitute. Changing those requires `UpgradeClient` (or a
+fresh client migration).
+
+## Caveats
+
+- The substitute's `LatestHeight` is not required to be greater than the
+  subject's. Same as ibc-go — nothing enforces a "forward" recovery, though in
+  practice the substitute is always ahead.
+- Only the substitute's consensus state **at its `LatestHeight`** is copied
+  into the subject. Earlier substitute consensus states are not migrated.
+- Recovery does not reset packet sequences or clear commitments — those are
+  packet-layer concerns and stay intact.

--- a/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"time"
+
+	"gno.land/p/aib/ibc/lightclient/tendermint"
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient success: a Frozen subject client is recovered using an Active
+// substitute client that tracks the same counterparty chain.
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+
+	// Subject client setup: create + freeze via misbehaviour (pattern from z8a).
+	var (
+		chainID     = "atomone-1"
+		height      = uint64(2)
+		clientState = tmtesting.NewClientState(chainID, types.NewHeight(1, height))
+		apphash     = tmtesting.Hash("apphash-2")
+		// priv=8a6cAbQSpDbebmcTEhCMPhhr/SkL/2pizo60yzHRkN9Uyk7RHOZm7g4xW+yeJh147/Z4/6HXF6gBwcFNkLsZ/A==
+		val1 = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=",
+			"VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 1)
+		// priv=nWg6ETc62tyxd94lh8fFaQnZKaAW6vlS0L/4lfseJuI14ZXUKp7AZROkflLFVF+SBg4wJVfzgzIKyWq3D066+g==
+		val2 = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=",
+			"NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 1)
+		trustedValset  = tendermint.NewValset(val1, val2)
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+
+	// Build valid misbehavior to freeze the subject.
+	var header1, header2 *tendermint.MsgHeader
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-4")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			newHeight       = uint64(4)
+			newTimestamp    = consensusState.Timestamp.Add(time.Minute * time.Duration(0))
+			nextValset      = tendermint.NewValset(val1, val2)
+			trustedHeight   = clientState.LatestHeight
+
+			signatures = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x2e\xba\x21\xb0\x2f\xd2\x85\xb9\xef\x82\x68\xdc\xef\xd1\xd1\x12\x70\x88\x94\x10\x7e\x4d\x49\xac\x46\x3d\x86\xe2\xf2\xae\x38\xb4\xa5\xab\x0c\xc1\x8f\x8a\x59\xda\x36\x17\x01\xe4\x16\x49\xbf\x03\x86\xf0\x31\x3f\x30\x37\x9e\x47\x28\x72\x3b\x0c\x89\xb9\x94\x05"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x67\xcc\xc6\xc4\x20\xa0\xcb\x36\xaf\x33\x5c\xf8\xe4\xad\x47\x49\x38\x9d\x9e\xa3\x7c\xe6\x88\x81\x62\x51\x7f\xcc\xa5\x92\x0d\x98\xe9\xbe\x71\x2d\x22\xcd\x41\x30\x28\x83\x03\xcb\xf5\xd7\x28\xde\x7b\x92\x85\x9e\xa6\xe5\xde\x50\x89\x2d\x2b\xc5\x9d\x9a\x33\x00"),
+				},
+			}
+		)
+		header1 = tmtesting.NewMsgHeader(chainID, newTimestamp, apphash, newHeight,
+			trustedHeight, valset, nextValset, trustedValset, signatures)
+	}
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-3")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			newHeight       = uint64(3)
+			newTimestamp    = consensusState.Timestamp.Add(time.Minute * time.Duration(0))
+			nextValset      = tendermint.NewValset(val1, val2)
+			trustedHeight   = clientState.LatestHeight
+
+			signatures = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x51\xa4\x8f\x78\x42\x4e\x6e\x0d\xc3\x2b\xe6\xcb\x09\x5c\xe5\x7d\x35\x84\xcf\xb1\x0f\x53\x72\x0c\x41\xde\xd3\x6d\xbc\x81\x28\x64\x41\xf7\xe9\x1e\xa9\x93\xd0\xa4\x84\x16\xca\xa8\xa3\x8e\x56\x45\xec\xae\x1d\x24\xb4\xa8\xf4\x29\x85\x04\x06\xe4\x18\x6b\x7d\x08"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\xd9\xd6\x82\x83\x78\x75\xfa\x2e\xd7\x1b\xa5\x3d\xfe\xb3\x80\xb6\xc7\x59\x20\x45\x10\xdf\x0c\x19\xd1\xcc\xfc\x37\xd5\x59\x79\x95\x93\x60\x08\xfb\x5f\xa0\x87\x95\x51\x1e\x29\xed\x94\xd1\x31\x5e\xda\x90\x86\x11\xbe\xb2\x88\x68\xe1\xba\xa7\x31\xc7\xa2\xda\x07"),
+				},
+			}
+		)
+		header2 = tmtesting.NewMsgHeader(chainID, newTimestamp, apphash, newHeight,
+			trustedHeight, valset, nextValset, trustedValset, signatures)
+	}
+	core.UpdateClient(cross, subjectID, &tendermint.Misbehaviour{Header1: header1, Header2: header2})
+
+	// Substitute client: fresh Active client with matching parameters (same
+	// chainID for IBC correctness, but the implementation also supports a
+	// different one — the subject will adopt the substitute's chainID).
+	substituteConsState := tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash-5"), trustedValset.Hash())
+	substituteID := core.CreateClient(cross, clientState, substituteConsState)
+
+	println("----------- before recover: subject status")
+	println(core.Render("clients/" + subjectID + "/status"))
+	println("----------- before recover: substitute status")
+	println(core.Render("clients/" + substituteID + "/status"))
+
+	core.RecoverClient(cross, subjectID, substituteID)
+
+	println("----------- after recover: subject status")
+	println(core.Render("clients/" + subjectID + "/status"))
+	println("----------- after recover: substitute status")
+	println(core.Render("clients/" + substituteID + "/status"))
+	println("----------- after recover: subject frozen_height (must be 0/0)")
+	println(core.Render("clients/" + subjectID))
+}
+
+// Output:
+// ----------- before recover: subject status
+// {"status":"Frozen"}
+// ----------- before recover: substitute status
+// {"status":"Active"}
+// ----------- after recover: subject status
+// {"status":"Active"}
+// ----------- after recover: substitute status
+// {"status":"Active"}
+// ----------- after recover: subject frozen_height (must be 0/0)
+// {"id":"07-tendermint-1","type":"07-tendermint","creator":"g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm","status":"Active","counterparty_client_id":"","counterparty_merke_prefix":[],"client_state":{"chain_id":"atomone-1","latest_height":{"revision_number":1,"revision_height":2},"frozen_height":{"revision_number":0,"revision_height":0},"trust_level":{"numerator":1,"denominator":3},"trusting_period":3600,"unbonding_period":10800,"max_clock_drift":3600,"upgrade_path":[]},"last_consensus_state":{"height":{"revision_number":1,"revision_height":2},"timestamp":1234567890,"root":"tcd+q9KGSkybZgSQ4cxkVM1s50yivY2V1QSgKN5/g8c=","next_validators_hash":"OJfJuH6dfiZI2d0uAxqamqfIVqV4c4oEAZigvJ8UqFQ="}}
+
+// Events:
+// [
+//   {
+//     "type": "create_client",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-1"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       },
+//       {
+//         "key": "consensus_heights",
+//         "value": "1/2"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "client_misbehaviour",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-1"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "create_client",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-2"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       },
+//       {
+//         "key": "consensus_heights",
+//         "value": "1/2"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "recover_client",
+//     "attrs": [
+//       {
+//         "key": "subject_client_id",
+//         "value": "07-tendermint-1"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   }
+// ]

--- a/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
@@ -102,6 +102,43 @@ func main() {
 	substituteConsState := tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash-5"), trustedValset.Hash())
 	substituteID := core.CreateClient(cross, clientState, substituteConsState)
 
+	// Advance the substitute to height (1,3) so recovery must actually adopt
+	// the substitute's LatestHeight (the subject starts at (1,2)). Signatures
+	// reused verbatim from z2a (chainID=atomone-1, height=3, apphash-3,
+	// trusted=(1,2), time-shift=1m).
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-3")
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			newHeight       = uint64(3)
+			newTimestamp    = substituteConsState.Timestamp.Add(time.Minute * time.Duration(1))
+			valset          = tendermint.NewValset(val1, val2)
+			nextValset      = tendermint.NewValset(val1, val2)
+			trustedHeight   = clientState.LatestHeight
+
+			signatures = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x5c\xd2\x8b\xe3\x4b\x60\x3e\xaa\x75\x3c\xce\x24\xfe\x15\x75\x55\x84\xd4\xa3\xce\xbe\x0f\x94\xe9\xf7\x27\xb3\x7a\xdd\x02\x2d\xa0\x0b\xa7\x83\x7f\x50\xc3\xde\x3d\x95\x59\xb3\xad\xed\xd0\xdd\x23\x1d\x39\x9a\x8e\x1f\xc3\xcf\xdb\x1d\xa9\x93\xf5\x9a\xc0\x2b\x05"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x34\x41\x2e\x78\x7f\xbf\x70\xef\x14\x48\xe3\x14\xd5\x83\xdc\x42\xff\x40\xf6\x5b\x71\x62\x09\xf9\x6f\x54\x63\x3e\xdb\xc5\x98\xc0\x9e\xa7\xde\x33\xac\xa7\x5f\xbb\xd6\x63\x49\xe1\xe9\x98\x86\x03\x46\x6a\x7e\xb6\x5d\xe5\x71\xe5\x1e\x5d\x4d\xd8\x8d\xbe\x2f\x01"),
+				},
+			}
+
+			msgHeader = tmtesting.NewMsgHeader(
+				"atomone-1", newTimestamp, apphash, newHeight, trustedHeight, valset,
+				nextValset, trustedValset, signatures,
+			)
+		)
+		core.UpdateClient(cross, substituteID, msgHeader)
+	}
+
 	println("----------- before recover: subject status")
 	println(core.Render("clients/" + subjectID + "/status"))
 	println("----------- before recover: substitute status")
@@ -127,7 +164,7 @@ func main() {
 // ----------- after recover: substitute status
 // {"status":"Active"}
 // ----------- after recover: subject frozen_height (must be 0/0)
-// {"id":"07-tendermint-1","type":"07-tendermint","creator":"g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm","status":"Active","counterparty_client_id":"","counterparty_merke_prefix":[],"client_state":{"chain_id":"atomone-1","latest_height":{"revision_number":1,"revision_height":2},"frozen_height":{"revision_number":0,"revision_height":0},"trust_level":{"numerator":1,"denominator":3},"trusting_period":3600,"unbonding_period":10800,"max_clock_drift":3600,"upgrade_path":[]},"last_consensus_state":{"height":{"revision_number":1,"revision_height":2},"timestamp":1234567890,"root":"tcd+q9KGSkybZgSQ4cxkVM1s50yivY2V1QSgKN5/g8c=","next_validators_hash":"OJfJuH6dfiZI2d0uAxqamqfIVqV4c4oEAZigvJ8UqFQ="}}
+// {"id":"07-tendermint-1","type":"07-tendermint","creator":"g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm","status":"Active","counterparty_client_id":"","counterparty_merke_prefix":[],"client_state":{"chain_id":"atomone-1","latest_height":{"revision_number":1,"revision_height":3},"frozen_height":{"revision_number":0,"revision_height":0},"trust_level":{"numerator":1,"denominator":3},"trusting_period":3600,"unbonding_period":10800,"max_clock_drift":3600,"upgrade_path":[]},"last_consensus_state":{"height":{"revision_number":1,"revision_height":3},"timestamp":1234567950,"root":"m9afpc+PXaYRHdGC7FkrzuzRNn8ONC1xRCzYYAPRCU8=","next_validators_hash":"OJfJuH6dfiZI2d0uAxqamqfIVqV4c4oEAZigvJ8UqFQ="}}
 
 // Events:
 // [
@@ -177,6 +214,24 @@ func main() {
 //       {
 //         "key": "consensus_heights",
 //         "value": "1/2"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "update_client",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-2"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       },
+//       {
+//         "key": "consensus_heights",
+//         "value": "1/3"
 //       }
 //     ],
 //     "pkg_path": "gno.land/r/aib/ibc/core"

--- a/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9a_recover_client_filetest.gno
@@ -189,6 +189,10 @@ func main() {
 //         "value": "07-tendermint-1"
 //       },
 //       {
+//         "key": "substitute_client_id",
+//         "value": "07-tendermint-2"
+//       },
+//       {
 //         "key": "client_type",
 //         "value": "07-tendermint"
 //       }

--- a/gno.land/r/aib/ibc/core/z9aa_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9aa_recover_client_filetest.gno
@@ -101,6 +101,10 @@ func main() {
 //         "value": "07-tendermint-1"
 //       },
 //       {
+//         "key": "substitute_client_id",
+//         "value": "07-tendermint-2"
+//       },
+//       {
 //         "key": "client_type",
 //         "value": "07-tendermint"
 //       }

--- a/gno.land/r/aib/ibc/core/z9aa_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9aa_recover_client_filetest.gno
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient success: an Expired subject client is recovered using an
+// Active substitute. Expiry is simulated by advancing block time past the
+// subject's TrustingPeriod via testing.SetContext.
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+
+	var (
+		chainID        = "chain-id-2"
+		clientState    = tmtesting.NewClientState(chainID, types.NewHeight(2, 2))
+		apphash        = tmtesting.Hash("apphash")
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+
+	// Advance block time past the subject's TrustingPeriod so its status
+	// becomes Expired.
+	ctx := testing.GetContext()
+	ctx.Time = time.Now().Add(clientState.TrustingPeriod)
+	testing.SetContext(ctx)
+
+	// Substitute is created AFTER the time jump, so its consensus state
+	// timestamp (time.Now() = ctx.Time) is fresh relative to the new clock.
+	substituteConsState := tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash-sub"), trustedValset.Hash())
+	substituteID := core.CreateClient(cross, clientState, substituteConsState)
+
+	println("----------- before recover: subject status")
+	println(core.Render("clients/" + subjectID + "/status"))
+	println("----------- before recover: substitute status")
+	println(core.Render("clients/" + substituteID + "/status"))
+
+	core.RecoverClient(cross, subjectID, substituteID)
+
+	println("----------- after recover: subject status")
+	println(core.Render("clients/" + subjectID + "/status"))
+}
+
+// Output:
+// ----------- before recover: subject status
+// {"status":"Expired"}
+// ----------- before recover: substitute status
+// {"status":"Active"}
+// ----------- after recover: subject status
+// {"status":"Active"}
+
+// Events:
+// [
+//   {
+//     "type": "create_client",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-1"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       },
+//       {
+//         "key": "consensus_heights",
+//         "value": "2/2"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "create_client",
+//     "attrs": [
+//       {
+//         "key": "client_id",
+//         "value": "07-tendermint-2"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       },
+//       {
+//         "key": "consensus_heights",
+//         "value": "2/2"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   },
+//   {
+//     "type": "recover_client",
+//     "attrs": [
+//       {
+//         "key": "subject_client_id",
+//         "value": "07-tendermint-1"
+//       },
+//       {
+//         "key": "client_type",
+//         "value": "07-tendermint"
+//       }
+//     ],
+//     "pkg_path": "gno.land/r/aib/ibc/core"
+//   }
+// ]

--- a/gno.land/r/aib/ibc/core/z9b_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9b_recover_client_filetest.gno
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: subject client not found.
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		clientState    = tmtesting.NewClientState("chain-id-2", types.NewHeight(2, 2))
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash"), trustedValset.Hash())
+	)
+	substituteID := core.CreateClient(cross, clientState, consensusState)
+
+	core.RecoverClient(cross, "07-tendermint-99", substituteID)
+}
+
+// Error:
+// subject client 07-tendermint-99 not found

--- a/gno.land/r/aib/ibc/core/z9c_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9c_recover_client_filetest.gno
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: substitute client not found.
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		clientState    = tmtesting.NewClientState("chain-id-2", types.NewHeight(2, 2))
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash"), trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+
+	core.RecoverClient(cross, subjectID, "07-tendermint-99")
+}
+
+// Error:
+// substitute client 07-tendermint-99 not found

--- a/gno.land/r/aib/ibc/core/z9d_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9d_recover_client_filetest.gno
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: subject client is Active (not Frozen or Expired).
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		clientState    = tmtesting.NewClientState("chain-id-2", types.NewHeight(2, 2))
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash"), trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+	substituteID := core.CreateClient(cross, clientState, consensusState)
+
+	core.RecoverClient(cross, subjectID, substituteID)
+}
+
+// Error:
+// cannot recover subject client 07-tendermint-1 with status Active

--- a/gno.land/r/aib/ibc/core/z9e_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9e_recover_client_filetest.gno
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"time"
+
+	"gno.land/p/aib/ibc/lightclient/tendermint"
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: substitute client is not Active (Frozen here).
+// Both subject and substitute are created with the same initial state, then
+// frozen via the same misbehaviour message.
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		chainID     = "atomone-1"
+		height      = uint64(2)
+		clientState = tmtesting.NewClientState(chainID, types.NewHeight(1, height))
+		apphash     = tmtesting.Hash("apphash-2")
+		val1        = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=",
+			"VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 1)
+		val2 = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=",
+			"NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 1)
+		trustedValset  = tendermint.NewValset(val1, val2)
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+	substituteID := core.CreateClient(cross, clientState, consensusState)
+
+	misbehaviour := buildMisbehaviour(chainID, clientState.LatestHeight, trustedValset, consensusState.Timestamp)
+	core.UpdateClient(cross, subjectID, misbehaviour)
+	core.UpdateClient(cross, substituteID, misbehaviour)
+
+	core.RecoverClient(cross, subjectID, substituteID)
+}
+
+func buildMisbehaviour(chainID string, trustedHeight types.Height,
+	trustedValset *tendermint.ValidatorSet, baseTime time.Time,
+) *tendermint.Misbehaviour {
+	var header1, header2 *tendermint.MsgHeader
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-4")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			newHeight       = uint64(4)
+			nextValset      = tendermint.NewValset(val1, val2)
+			signatures      = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x2e\xba\x21\xb0\x2f\xd2\x85\xb9\xef\x82\x68\xdc\xef\xd1\xd1\x12\x70\x88\x94\x10\x7e\x4d\x49\xac\x46\x3d\x86\xe2\xf2\xae\x38\xb4\xa5\xab\x0c\xc1\x8f\x8a\x59\xda\x36\x17\x01\xe4\x16\x49\xbf\x03\x86\xf0\x31\x3f\x30\x37\x9e\x47\x28\x72\x3b\x0c\x89\xb9\x94\x05"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x67\xcc\xc6\xc4\x20\xa0\xcb\x36\xaf\x33\x5c\xf8\xe4\xad\x47\x49\x38\x9d\x9e\xa3\x7c\xe6\x88\x81\x62\x51\x7f\xcc\xa5\x92\x0d\x98\xe9\xbe\x71\x2d\x22\xcd\x41\x30\x28\x83\x03\xcb\xf5\xd7\x28\xde\x7b\x92\x85\x9e\xa6\xe5\xde\x50\x89\x2d\x2b\xc5\x9d\x9a\x33\x00"),
+				},
+			}
+		)
+		header1 = tmtesting.NewMsgHeader(chainID, baseTime, apphash, newHeight,
+			trustedHeight, valset, nextValset, trustedValset, signatures)
+	}
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-3")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			newHeight       = uint64(3)
+			nextValset      = tendermint.NewValset(val1, val2)
+			signatures      = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x51\xa4\x8f\x78\x42\x4e\x6e\x0d\xc3\x2b\xe6\xcb\x09\x5c\xe5\x7d\x35\x84\xcf\xb1\x0f\x53\x72\x0c\x41\xde\xd3\x6d\xbc\x81\x28\x64\x41\xf7\xe9\x1e\xa9\x93\xd0\xa4\x84\x16\xca\xa8\xa3\x8e\x56\x45\xec\xae\x1d\x24\xb4\xa8\xf4\x29\x85\x04\x06\xe4\x18\x6b\x7d\x08"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\xd9\xd6\x82\x83\x78\x75\xfa\x2e\xd7\x1b\xa5\x3d\xfe\xb3\x80\xb6\xc7\x59\x20\x45\x10\xdf\x0c\x19\xd1\xcc\xfc\x37\xd5\x59\x79\x95\x93\x60\x08\xfb\x5f\xa0\x87\x95\x51\x1e\x29\xed\x94\xd1\x31\x5e\xda\x90\x86\x11\xbe\xb2\x88\x68\xe1\xba\xa7\x31\xc7\xa2\xda\x07"),
+				},
+			}
+		)
+		header2 = tmtesting.NewMsgHeader(chainID, baseTime, apphash, newHeight,
+			trustedHeight, valset, nextValset, trustedValset, signatures)
+	}
+	return &tendermint.Misbehaviour{Header1: header1, Header2: header2}
+}
+
+// Error:
+// substitute client 07-tendermint-2 must be Active, got Frozen

--- a/gno.land/r/aib/ibc/core/z9f_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9f_recover_client_filetest.gno
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: caller is not the admin.
+func main() {
+	// Admin is set to a different address than the test caller.
+	core.SetAdmin(cross, "g1somebodyelse00000000000000000000000000")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		clientState    = tmtesting.NewClientState("chain-id-2", types.NewHeight(2, 2))
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), tmtesting.Hash("apphash"), trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+	substituteID := core.CreateClient(cross, clientState, consensusState)
+
+	core.RecoverClient(cross, subjectID, substituteID)
+}
+
+// Error:
+// unauthorized: caller g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm is not the admin

--- a/gno.land/r/aib/ibc/core/z9g_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9g_recover_client_filetest.gno
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"time"
+
+	"gno.land/p/aib/ibc/lightclient/tendermint"
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+	"gno.land/r/aib/ibc/core"
+)
+
+// RecoverClient failure: substitute has mismatching immutable client state
+// (different MaxClockDrift).
+func main() {
+	core.SetAdmin(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	core.AddRelayer(cross, "g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm")
+	var (
+		chainID     = "atomone-1"
+		height      = uint64(2)
+		clientState = tmtesting.NewClientState(chainID, types.NewHeight(1, height))
+		apphash     = tmtesting.Hash("apphash-2")
+		val1        = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=",
+			"VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 1)
+		val2 = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=",
+			"NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 1)
+		trustedValset  = tendermint.NewValset(val1, val2)
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	subjectID := core.CreateClient(cross, clientState, consensusState)
+
+	// Freeze the subject via misbehaviour so it reaches Frozen status.
+	header1, header2 := freezingHeaders(chainID, clientState.LatestHeight, trustedValset, consensusState.Timestamp)
+	core.UpdateClient(cross, subjectID, &tendermint.Misbehaviour{Header1: header1, Header2: header2})
+
+	// Substitute has a different MaxClockDrift (30m instead of default 1h).
+	substituteState := tmtesting.NewClientState(chainID, clientState.LatestHeight)
+	substituteState.MaxClockDrift = 30 * time.Minute
+	substituteID := core.CreateClient(cross, substituteState, consensusState)
+
+	core.RecoverClient(cross, subjectID, substituteID)
+}
+
+func freezingHeaders(chainID string, trustedHeight types.Height,
+	trustedValset *tendermint.ValidatorSet, baseTime time.Time,
+) (*tendermint.MsgHeader, *tendermint.MsgHeader) {
+	var header1, header2 *tendermint.MsgHeader
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-4")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			signatures      = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x2e\xba\x21\xb0\x2f\xd2\x85\xb9\xef\x82\x68\xdc\xef\xd1\xd1\x12\x70\x88\x94\x10\x7e\x4d\x49\xac\x46\x3d\x86\xe2\xf2\xae\x38\xb4\xa5\xab\x0c\xc1\x8f\x8a\x59\xda\x36\x17\x01\xe4\x16\x49\xbf\x03\x86\xf0\x31\x3f\x30\x37\x9e\x47\x28\x72\x3b\x0c\x89\xb9\x94\x05"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x67\xcc\xc6\xc4\x20\xa0\xcb\x36\xaf\x33\x5c\xf8\xe4\xad\x47\x49\x38\x9d\x9e\xa3\x7c\xe6\x88\x81\x62\x51\x7f\xcc\xa5\x92\x0d\x98\xe9\xbe\x71\x2d\x22\xcd\x41\x30\x28\x83\x03\xcb\xf5\xd7\x28\xde\x7b\x92\x85\x9e\xa6\xe5\xde\x50\x89\x2d\x2b\xc5\x9d\x9a\x33\x00"),
+				},
+			}
+		)
+		header1 = tmtesting.NewMsgHeader(chainID, baseTime, apphash, 4,
+			trustedHeight, valset, tendermint.NewValset(val1, val2), trustedValset, signatures)
+	}
+	{
+		var (
+			apphash         = tmtesting.Hash("apphash-3")
+			val1            = tendermint.NewValidator("9DIBYr64rywKO3Kk6+743xDHcEU=", "VMpO0RzmZu4OMVvsniYdeO/2eP+h1xeoAcHBTZC7Gfw=", 10)
+			val2            = tendermint.NewValidator("y+naL3ubs9q1bXrY9+uRxY9c+J8=", "NeGV1CqewGUTpH5SxVRfkgYOMCVX84MyCslqtw9Ouvo=", 10)
+			valset          = tendermint.NewValset(val1, val2)
+			commitTimestamp = tmtesting.ToTime("2025-09-25T07:55:57.306746166Z")
+			signatures      = []tendermint.CommitSig{
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[0].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\x51\xa4\x8f\x78\x42\x4e\x6e\x0d\xc3\x2b\xe6\xcb\x09\x5c\xe5\x7d\x35\x84\xcf\xb1\x0f\x53\x72\x0c\x41\xde\xd3\x6d\xbc\x81\x28\x64\x41\xf7\xe9\x1e\xa9\x93\xd0\xa4\x84\x16\xca\xa8\xa3\x8e\x56\x45\xec\xae\x1d\x24\xb4\xa8\xf4\x29\x85\x04\x06\xe4\x18\x6b\x7d\x08"),
+				},
+				{
+					BlockIDFlag:      tendermint.BlockIDFlagCommit,
+					ValidatorAddress: valset.Validators[1].Address,
+					Timestamp:        commitTimestamp,
+					Signature:        []byte("\xd9\xd6\x82\x83\x78\x75\xfa\x2e\xd7\x1b\xa5\x3d\xfe\xb3\x80\xb6\xc7\x59\x20\x45\x10\xdf\x0c\x19\xd1\xcc\xfc\x37\xd5\x59\x79\x95\x93\x60\x08\xfb\x5f\xa0\x87\x95\x51\x1e\x29\xed\x94\xd1\x31\x5e\xda\x90\x86\x11\xbe\xb2\x88\x68\xe1\xba\xa7\x31\xc7\xa2\xda\x07"),
+				},
+			}
+		)
+		header2 = tmtesting.NewMsgHeader(chainID, baseTime, apphash, 3,
+			trustedHeight, valset, tendermint.NewValset(val1, val2), trustedValset, signatures)
+	}
+	return header1, header2
+}
+
+// Error:
+// subject client state does not match substitute client state

--- a/gno.land/r/aib/ibc/core/z9g_recover_client_filetest.gno
+++ b/gno.land/r/aib/ibc/core/z9g_recover_client_filetest.gno
@@ -98,4 +98,4 @@ func freezingHeaders(chainID string, trustedHeight types.Height,
 }
 
 // Error:
-// subject client state does not match substitute client state
+// subject and substitute client states differ on MaxClockDrift


### PR DESCRIPTION
Closes #15

Admin-gated RecoverClient revives a Frozen or Expired subject client by
copying state from a healthy substitute tracking the same counterparty
chain. Mirrors ibc-go's MsgRecoverClient: ChainID, LatestHeight and
TrustingPeriod are adopted from the substitute, FrozenHeight is reset,
and the substitute's consensus state at its latest height is copied in.
Immutable client parameters (TrustLevel, UnbondingPeriod, MaxClockDrift,
ProofSpecs, UpgradePath) must match.

- Change lightclient.Interface.RecoverClient signature to take the
  substitute Interface (needed for TMLightClient to read substitute state)
- Add strict Equal methods on ics23.ProofSpec, LeafOp and InnerSpec
  (SpecEquals kept for its existing looser callers)
- Unit tests for TMLightClient.RecoverClient and ics23 Equal methods
- Filetests z9a/z9aa (success from Frozen/Expired) and z9b-z9g
  (failure paths)
- recover-client.md documents the full flow, parameter-change
  semantics, and post-recovery state of the substitute