### PR TITLE
chore: remove `realm.SentCoins()`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ IBC voucher tokens (minted on RecvPacket for cross-chain tokens) use **GRC20 tok
 
 ### What Uses Native Banker
 - **Escrow/unescrow** of native tokens (ugnot, etc.) still uses `chain/banker`
-- Native token escrow in `OnSendPacket` uses `banker.OriginSend()` to verify coins sent with the transaction
+- `Transfer()` is the only valid entry point for native coin transfers. It verifies the user attached the matching `-send` via `banker.OriginSend()` guarded by `runtime.PreviousRealm().IsUserCall()`. The `IsUserCall` guard is what makes `OriginSend()` trustworthy — it ensures the coins actually landed at this realm, not at an intermediate code realm that forwarded the call. The verified coin is handed off to `OnSendPacket` through a package-level pointer (`pendingNativeEscrow`) cleared by a `defer` in `Transfer` so it never leaks across txs. `OnSendPacket` doesn't re-read `OriginSend()` because its `PreviousRealm()` is the core realm and the guard would always fail there; relying on the upstream `Transfer` check is structurally simpler than re-deriving it.
 
 ### Voucher Render Endpoints
 - `voucher/ibc/{hash}` - Token info (name, symbol, total supply)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ IBC voucher tokens (minted on RecvPacket for cross-chain tokens) use **GRC20 tok
 
 ### What Uses Native Banker
 - **Escrow/unescrow** of native tokens (ugnot, etc.) still uses `chain/banker`
-- Native token escrow in `OnSendPacket` uses `cur.SentCoins()` to verify coins sent with the transaction
+- Native token escrow in `OnSendPacket` uses `banker.OriginSend()` to verify coins sent with the transaction
 
 ### Voucher Render Endpoints
 - `voucher/ibc/{hash}` - Token info (name, symbol, total supply)

--- a/gno.land/r/aib/ibc/apps/transfer/README.md
+++ b/gno.land/r/aib/ibc/apps/transfer/README.md
@@ -10,7 +10,7 @@ token type is detected automatically from the `denom` argument:
 
 | Token type | Denom format | Example | Mechanism |
 |---|---|---|---|
-| Native coin | plain string | `ugnot` | Escrowed via `SentCoins` |
+| Native coin | plain string | `ugnot` | Escrowed via `banker.OriginSend` (direct user-call only) |
 | IBC voucher | `ibc/{hash}` | `ibc/CAEF9C...` | Burned from sender |
 | GRC20 token | grc20reg key | `gno.land/r/demo/foo.FOO` | Escrowed via `TransferFrom` |
 
@@ -31,7 +31,11 @@ func Transfer(
 ### Native coin
 
 The coin must be attached to the transaction via the `-send` flag and must match
-`denom` and `amount`.
+`denom` and `amount`. Only direct user calls (`gnokey maketx call`) are
+accepted: `Transfer` reads `banker.OriginSend()` guarded by
+`runtime.PreviousRealm().IsUserCall()` to ensure the coins actually landed at
+this realm. Calls from intermediate code realms or `maketx run` ephemeral
+realms are rejected.
 
 ```
 gnokey maketx call -pkgpath gno.land/r/aib/ibc/apps/transfer -func Transfer \

--- a/gno.land/r/aib/ibc/apps/transfer/app.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/app.gno
@@ -124,7 +124,7 @@ func (a *App) OnSendPacket(
 		addEscrowForDenom(coin)
 	} else {
 		// Native token: ensure that sent coin matches the FungibleTokenPacketData
-		sent := cur.SentCoins()
+		sent := sentCoins()
 		if len(sent) != 1 || sent[0].Amount == 0 {
 			return ufmt.Errorf("OnSendPacket requires one non-zero coin to be sent for native token transfer")
 		}

--- a/gno.land/r/aib/ibc/apps/transfer/app.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/app.gno
@@ -123,15 +123,20 @@ func (a *App) OnSendPacket(
 		}
 		addEscrowForDenom(coin)
 	} else {
-		// Native token: ensure that sent coin matches the FungibleTokenPacketData
-		sent := sentCoins()
-		if len(sent) != 1 || sent[0].Amount == 0 {
-			return ufmt.Errorf("OnSendPacket requires one non-zero coin to be sent for native token transfer")
+		// Native token: OnSendPacket cannot safely read banker.OriginSend()
+		// here because PreviousRealm() is the core realm (not the EOA), so
+		// the escrow envelope is verified upstream by Transfer() and handed
+		// off via pendingNativeEscrow. A direct caller of core.SendPacket
+		// for a native packet will find the slot nil and be rejected.
+		// Transfer's defer is responsible for clearing the slot.
+		if pendingNativeEscrow == nil {
+			return ufmt.Errorf("native packet must be initiated through transfer.Transfer")
 		}
-		if coin.Denom != sent[0].Denom || coin.Amount != sent[0].Amount {
+		expected := *pendingNativeEscrow
+		if coin.Denom != expected.Denom || coin.Amount != expected.Amount {
 			return ufmt.Errorf(
-				"coin sent %s is not equal to fungible packet data token %s",
-				sent[0], coin,
+				"escrowed coin %s is not equal to fungible packet data token %s",
+				expected, coin,
 			)
 		}
 		// Escrow the coin on realm balance

--- a/gno.land/r/aib/ibc/apps/transfer/transfer.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/transfer.gno
@@ -84,9 +84,6 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 // VoucherSend is a convenience helper to send an IBC voucher token from the
 // caller to the provided recipient.
 func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
-	if runtime.PreviousRealm().IsUserCall() && len(banker.OriginSend()) > 0 {
-		panic("voucher transfer must not include native coins")
-	}
 	inst := getVoucher(ibcDenom)
 	if inst == nil {
 		panic(ufmt.Errorf("voucher token not found for denom %s", ibcDenom))
@@ -100,9 +97,6 @@ func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
 // VoucherApprove is a convenience helper to set a spender allowance for an IBC
 // voucher token on behalf of the caller.
 func VoucherApprove(cur realm, ibcDenom string, spender address, amount int64) {
-	if runtime.PreviousRealm().IsUserCall() && len(banker.OriginSend()) > 0 {
-		panic("voucher approval must not include native coins")
-	}
 	inst := getVoucher(ibcDenom)
 	if inst == nil {
 		panic(ufmt.Errorf("voucher token not found for denom %s", ibcDenom))

--- a/gno.land/r/aib/ibc/apps/transfer/transfer.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/transfer.gno
@@ -38,7 +38,7 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 	case grc20reg.Get(denom) != nil:
 		// Non-IBC GRC20 token: convert to alias.
 		// Escrow via TransferFrom happens in OnSendPacket.
-		if sent := cur.SentCoins(); len(sent) > 0 {
+		if sent := sentCoins(); len(sent) > 0 {
 			panic("GRC20 transfer must not include native coins")
 		}
 		// Replace the denom with a slash-free alias for the IBC packet.
@@ -52,7 +52,7 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 		panic(ufmt.Sprintf("GRC20 token %s not found in grc20reg", denom))
 	default:
 		// Native coin: verify SentCoins matches.
-		sent := cur.SentCoins()
+		sent := sentCoins()
 		if len(sent) != 1 || sent[0].Amount == 0 {
 			panic("native transfer requires one non-zero coin to be sent")
 		}
@@ -69,7 +69,7 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 // VoucherSend is a convenience helper to send an IBC voucher token from the
 // caller to the provided recipient.
 func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
-	if sent := cur.SentCoins(); len(sent) > 0 {
+	if sent := sentCoins(); len(sent) > 0 {
 		panic("voucher transfer must not include native coins")
 	}
 	inst := getVoucher(ibcDenom)
@@ -85,7 +85,7 @@ func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
 // VoucherApprove is a convenience helper to set a spender allowance for an IBC
 // voucher token on behalf of the caller.
 func VoucherApprove(cur realm, ibcDenom string, spender address, amount int64) {
-	if sent := cur.SentCoins(); len(sent) > 0 {
+	if sent := sentCoins(); len(sent) > 0 {
 		panic("voucher approval must not include native coins")
 	}
 	inst := getVoucher(ibcDenom)
@@ -180,4 +180,12 @@ func unescrowNative(receiver string, coin chain.Coin) error {
 	banker.SendCoins(from, to, amount)
 	subEscrowForDenom(coin)
 	return nil
+}
+
+func sentCoins() []chain.Coin {
+	println("PKGPATH", runtime.CurrentRealm().PkgPath())
+	if !runtime.CurrentRealm().IsUserCall() {
+		return nil
+	}
+	return banker.OriginSend()
 }

--- a/gno.land/r/aib/ibc/apps/transfer/transfer.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/transfer.gno
@@ -38,7 +38,10 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 	case grc20reg.Get(denom) != nil:
 		// Non-IBC GRC20 token: convert to alias.
 		// Escrow via TransferFrom happens in OnSendPacket.
-		if sent := sentCoins(); len(sent) > 0 {
+		// Only catch the "stuck coins" mistake on direct user calls;
+		// when a wrapper realm calls us, OriginSend describes the outer
+		// tx envelope and the coins did not land at this realm.
+		if runtime.PreviousRealm().IsUserCall() && len(banker.OriginSend()) > 0 {
 			panic("GRC20 transfer must not include native coins")
 		}
 		// Replace the denom with a slash-free alias for the IBC packet.
@@ -51,8 +54,14 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 		// confusing "requires one non-zero coin to be sent" error.
 		panic(ufmt.Sprintf("GRC20 token %s not found in grc20reg", denom))
 	default:
-		// Native coin: verify SentCoins matches.
-		sent := sentCoins()
+		// Native coin: only direct user-call (maketx call) is accepted, so
+		// banker.OriginSend() describes coins that actually landed at this
+		// realm. Intermediate code realms or `maketx run` ephemeral realms
+		// can attach -send to the tx but spend it elsewhere.
+		if !runtime.PreviousRealm().IsUserCall() {
+			panic("native transfer must be a direct user call (maketx call)")
+		}
+		sent := banker.OriginSend()
 		if len(sent) != 1 || sent[0].Amount == 0 {
 			panic("native transfer requires one non-zero coin to be sent")
 		}
@@ -62,6 +71,12 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 				sent[0], denom, amount,
 			))
 		}
+		// Hand the verified escrow off to OnSendPacket, which can no longer
+		// safely read OriginSend (its PreviousRealm is the core realm).
+		// The defer below guarantees we clear the slot in any exit path so
+		// a leftover never bleeds into a later call.
+		pendingNativeEscrow = &sent[0]
+		defer func() { pendingNativeEscrow = nil }()
 	}
 	return transfer(clientID, receiver, denom, amount, timeoutTimestamp, memo)
 }
@@ -69,7 +84,7 @@ func Transfer(cur realm, clientID, receiver, denom string, amount int64, timeout
 // VoucherSend is a convenience helper to send an IBC voucher token from the
 // caller to the provided recipient.
 func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
-	if sent := sentCoins(); len(sent) > 0 {
+	if runtime.PreviousRealm().IsUserCall() && len(banker.OriginSend()) > 0 {
 		panic("voucher transfer must not include native coins")
 	}
 	inst := getVoucher(ibcDenom)
@@ -85,7 +100,7 @@ func VoucherSend(cur realm, ibcDenom string, to address, amount int64) {
 // VoucherApprove is a convenience helper to set a spender allowance for an IBC
 // voucher token on behalf of the caller.
 func VoucherApprove(cur realm, ibcDenom string, spender address, amount int64) {
-	if sent := sentCoins(); len(sent) > 0 {
+	if runtime.PreviousRealm().IsUserCall() && len(banker.OriginSend()) > 0 {
 		panic("voucher approval must not include native coins")
 	}
 	inst := getVoucher(ibcDenom)
@@ -182,10 +197,12 @@ func unescrowNative(receiver string, coin chain.Coin) error {
 	return nil
 }
 
-func sentCoins() []chain.Coin {
-	println("PKGPATH", runtime.CurrentRealm().PkgPath())
-	if !runtime.CurrentRealm().IsUserCall() {
-		return nil
-	}
-	return banker.OriginSend()
-}
+// pendingNativeEscrow is set by Transfer's native branch and read by
+// OnSendPacket. It bridges the user-call boundary check (only doable from
+// Transfer, where PreviousRealm() is the EOA) to the actual escrow update
+// (done in OnSendPacket).
+//
+// Gno persists package-level vars to the realm store at end of tx, so this
+// MUST be cleared before Transfer returns to avoid leaking into the next
+// tx. Transfer uses a defer to guarantee the reset on every exit path.
+var pendingNativeEscrow *chain.Coin

--- a/gno.land/r/aib/ibc/apps/transfer/z1a_on_send_packet_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z1a_on_send_packet_filetest.gno
@@ -53,4 +53,4 @@ func main() {
 }
 
 // Error:
-// send packet failed for payload #0 app "transfer": OnSendPacket requires one non-zero coin to be sent for native token transfer
+// send packet failed for payload #0 app "transfer": native packet must be initiated through transfer.Transfer

--- a/gno.land/r/aib/ibc/apps/transfer/z2a_on_ack_packet_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z2a_on_ack_packet_filetest.gno
@@ -29,6 +29,7 @@ func main() {
 	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, counterpartyID)
 
 	// Transfer the 100ugnot we want to ack
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(chain.NewCoins(chain.NewCoin("ugnot", 100)))
 	println("----------- assert render total_escrow/ugnot before Transfer")
 	println(transfer.Render("total_escrow/ugnot"))

--- a/gno.land/r/aib/ibc/apps/transfer/z2aa_on_ack_packet_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z2aa_on_ack_packet_filetest.gno
@@ -29,6 +29,7 @@ func main() {
 
 	// Transfer the 100ugnot we want to ack
 	coins := chain.NewCoins(chain.NewCoin("ugnot", 100))
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(coins)
 	println("----------- assert render total_escrow/ugnot before Transfer")
 	println(transfer.Render("total_escrow/ugnot"))

--- a/gno.land/r/aib/ibc/apps/transfer/z2b_on_ack_packet_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z2b_on_ack_packet_filetest.gno
@@ -29,6 +29,7 @@ func main() {
 	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, counterpartyID)
 
 	// Transfer the 100ugnot we want to ack
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(chain.NewCoins(chain.NewCoin("ugnot", 100)))
 	println("----------- assert render total_escrow/ugnot before Transfer")
 	println(transfer.Render("total_escrow/ugnot"))

--- a/gno.land/r/aib/ibc/apps/transfer/z2c_on_ack_packet_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z2c_on_ack_packet_filetest.gno
@@ -28,6 +28,7 @@ func main() {
 	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, counterpartyID)
 
 	// Transfer the 100ugnot we want to ack
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(chain.NewCoins(chain.NewCoin("ugnot", 100)))
 	println("----------- assert render total_escrow/ugnot before Transfer")
 	println(transfer.Render("total_escrow/ugnot"))

--- a/gno.land/r/aib/ibc/apps/transfer/z3a_on_timeout_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z3a_on_timeout_filetest.gno
@@ -36,6 +36,7 @@ func main() {
 
 	// Transfer the 100ugnot we want to ack
 	coins := chain.NewCoins(chain.NewCoin("ugnot", 100))
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(coins)
 	println("----------- assert render total_escrow/ugnot before Transfer")
 	println(transfer.Render("total_escrow/ugnot"))

--- a/gno.land/r/aib/ibc/apps/transfer/z5a_transfer_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z5a_transfer_filetest.gno
@@ -2,7 +2,6 @@ package main
 
 import (
 	"chain"
-	"chain/runtime"
 	"testing"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 
 // Transfer: success for native coins
 func main() {
-	println("PKGPATH0", runtime.CurrentRealm().PkgPath())
 	var (
 		chainID        = "chain-id-2"
 		clientState    = tmtesting.NewClientState(chainID, types.NewHeight(2, 2))
@@ -26,6 +24,7 @@ func main() {
 	clientID := core.CreateClient(cross, clientState, consensusState)
 	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, "07-tendermint-2")
 
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	testing.SetOriginSend(chain.NewCoins(chain.NewCoin("ugnot", 100)))
 
 	println("----------- assert render total_escrow/ugnot before Transfer")

--- a/gno.land/r/aib/ibc/apps/transfer/z5a_transfer_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z5a_transfer_filetest.gno
@@ -2,6 +2,7 @@ package main
 
 import (
 	"chain"
+	"chain/runtime"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 
 // Transfer: success for native coins
 func main() {
+	println("PKGPATH0", runtime.CurrentRealm().PkgPath())
 	var (
 		chainID        = "chain-id-2"
 		clientState    = tmtesting.NewClientState(chainID, types.NewHeight(2, 2))

--- a/gno.land/r/aib/ibc/apps/transfer/z5b_transfer_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z5b_transfer_filetest.gno
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"testing"
 	"time"
 
 	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
@@ -22,6 +23,7 @@ func main() {
 	clientID := core.CreateClient(cross, clientState, consensusState)
 	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, "07-tendermint-2")
 
+	testing.SetRealm(testing.NewUserRealm("g1wymu47drhr0kuq2098m792lytgtj2nyx77yrsm"))
 	transfer.Transfer(cross, clientID, "atone1user", "ugnot", 100, uint64(time.Now().Add(time.Hour).Unix()), "")
 }
 

--- a/gno.land/r/aib/ibc/apps/transfer/z5f_transfer_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/z5f_transfer_filetest.gno
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"chain"
+	"testing"
+	"time"
+
+	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
+	"gno.land/p/aib/ibc/types"
+
+	"gno.land/r/aib/ibc/apps/transfer"
+	"gno.land/r/aib/ibc/core"
+)
+
+// Transfer: native denom is rejected when the caller is not a direct user
+// call. This is the maketx-run / wrapper-realm scenario the IsUserCall guard
+// exists to block: -send can land elsewhere than this realm, so OriginSend
+// cannot be trusted.
+func main() {
+	var (
+		chainID        = "chain-id-2"
+		clientState    = tmtesting.NewClientState(chainID, types.NewHeight(2, 2))
+		apphash        = tmtesting.Hash("apphash")
+		trustedValset  = tmtesting.GenValset()
+		consensusState = tmtesting.GenConsensusState(time.Now(), apphash, trustedValset.Hash())
+	)
+	clientID := core.CreateClient(cross, clientState, consensusState)
+	core.RegisterCounterparty(cross, clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, "07-tendermint-2")
+
+	// Deliberately no testing.SetRealm(NewUserRealm(...)) — default package
+	// main caller fails IsUserCall(), matching maketx run / wrapper realm.
+	// OriginSend is set to prove the guard fires before any amount check.
+	testing.SetOriginSend(chain.NewCoins(chain.NewCoin("ugnot", 100)))
+	transfer.Transfer(cross, clientID, "atone1user", "ugnot", 100, uint64(time.Now().Add(time.Hour).Unix()), "")
+}
+
+// Error:
+// native transfer must be a direct user call (maketx call)

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module aibgno
 go 1.25.3
 
 replace (
-	github.com/gnolang/gno => github.com/allinbits/gno v0.0.0-20260421084646-d2aeb752216b
-	github.com/gnolang/gno/contribs/gnodev => github.com/allinbits/gno/contribs/gnodev v0.0.0-20260421084646-d2aeb752216b
+	github.com/gnolang/gno => github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008
+	github.com/gnolang/gno/contribs/gnodev => github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008
 )
 
 tool (

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module aibgno
 go 1.25.3
 
 replace (
-	github.com/gnolang/gno => github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008
-	github.com/gnolang/gno/contribs/gnodev => github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008
+	github.com/gnolang/gno => github.com/allinbits/gno v0.0.0-20260507131421-7b53e6502815
+	github.com/gnolang/gno/contribs/gnodev => github.com/allinbits/gno/contribs/gnodev v0.0.0-20260507131421-7b53e6502815
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,10 @@ github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9c
 github.com/alecthomas/repr v0.0.0-20220113201626-b1b626ac65ae/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/allinbits/gno v0.0.0-20260421084646-d2aeb752216b h1:8u4FH5/g1eOlkqLRJCPZNK0V+mqcWOh3zO2KSqt4H7g=
-github.com/allinbits/gno v0.0.0-20260421084646-d2aeb752216b/go.mod h1:s+DaVo0aAIrKBTYhj5T5vVDp0nw7a5bcOatoUJ6I9/Y=
-github.com/allinbits/gno/contribs/gnodev v0.0.0-20260421084646-d2aeb752216b h1:bhUzjz/lbSC3inkBfra0IcuEM2AAHLaFdbcyPoQwLZg=
-github.com/allinbits/gno/contribs/gnodev v0.0.0-20260421084646-d2aeb752216b/go.mod h1:JbxF0iCH1tAqDi3JBsI9MjZJqgWOLpvX9AfmQR2Acqc=
+github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008 h1:grd+i1KpCP7AFta0kjNYHb6g/O4zLprXwjolrKtIpqs=
+github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008/go.mod h1:s+DaVo0aAIrKBTYhj5T5vVDp0nw7a5bcOatoUJ6I9/Y=
+github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008 h1:lHN8Dnkwwb4PSQAC63f8ZbDnIWYOMFrVUoBS6sF9cAA=
+github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008/go.mod h1:JbxF0iCH1tAqDi3JBsI9MjZJqgWOLpvX9AfmQR2Acqc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bendory/conway-hebrew-calendar v0.0.0-20210829020739-dcc34210ce9b h1:AqcWTgnij9lTMsvc21uXU38gVQyzsb4i1YDRJja+auc=

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,10 @@ github.com/alecthomas/chroma/v2 v2.23.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9c
 github.com/alecthomas/repr v0.0.0-20220113201626-b1b626ac65ae/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008 h1:grd+i1KpCP7AFta0kjNYHb6g/O4zLprXwjolrKtIpqs=
-github.com/allinbits/gno v0.0.0-20260506100757-c54f3359c008/go.mod h1:s+DaVo0aAIrKBTYhj5T5vVDp0nw7a5bcOatoUJ6I9/Y=
-github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008 h1:lHN8Dnkwwb4PSQAC63f8ZbDnIWYOMFrVUoBS6sF9cAA=
-github.com/allinbits/gno/contribs/gnodev v0.0.0-20260506100757-c54f3359c008/go.mod h1:JbxF0iCH1tAqDi3JBsI9MjZJqgWOLpvX9AfmQR2Acqc=
+github.com/allinbits/gno v0.0.0-20260507131421-7b53e6502815 h1:R9Px76fje8Kpnbe2OwWwZRBC7erLPRVcnBppu5wWU4c=
+github.com/allinbits/gno v0.0.0-20260507131421-7b53e6502815/go.mod h1:s+DaVo0aAIrKBTYhj5T5vVDp0nw7a5bcOatoUJ6I9/Y=
+github.com/allinbits/gno/contribs/gnodev v0.0.0-20260507131421-7b53e6502815 h1:knnShJO0PF4OsKXqsfszLYzuPfVM8pLPPfs8MA7KmOs=
+github.com/allinbits/gno/contribs/gnodev v0.0.0-20260507131421-7b53e6502815/go.mod h1:JbxF0iCH1tAqDi3JBsI9MjZJqgWOLpvX9AfmQR2Acqc=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/bendory/conway-hebrew-calendar v0.0.0-20210829020739-dcc34210ce9b h1:AqcWTgnij9lTMsvc21uXU38gVQyzsb4i1YDRJja+auc=


### PR DESCRIPTION
Migrate native-coin escrow off the removed realm.SentCoins API. Transfer
now reads `banker.OriginSend()` under a `runtime.PreviousRealm().IsUserCall()`
guard (the only frame where the envelope is known to have landed at this
realm) and hands the verified coin to `OnSendPacket` through a transient
package var cleared by defer to avoid leaking across txs.

The "no native coins attached" guards on the GRC20 / voucher helpers are
also gated on `IsUserCall` so wrapper realms composing those entry points
don't trip on the outer tx's -send envelope.

Filetests use `testing.SetRealm(NewUserRealm(...)) `for native flows, since
package main otherwise has `PreviousRealm.IsUserCall=false`.