### PR TITLE
feat(transfer): show client status and trusted height on render page

### DIFF
--- a/gno.land/r/aib/ibc/apps/transfer/filetests/z0bbb_render_home_expired_client_filetest.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/filetests/z0bbb_render_home_expired_client_filetest.gno
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"testing"
 	"time"
 
 	tmtesting "gno.land/p/aib/ibc/lightclient/tendermint/testing"
@@ -11,8 +12,11 @@ import (
 	"gno.land/r/aib/ibc/core"
 )
 
-// renderHome with a client registered: confirms the Transfer section lists one
-// txlink row per known client (pre-filling clientID).
+// renderHome with a non-active (Expired) client: confirms the Transfer section
+// still lists the client with its status and trusted height, but omits the
+// "send via" txlink since packets can't be sent through it. The client is
+// created Active, then block time is advanced past the trusting period to
+// expire it.
 func main(cur realm) {
 	var (
 		chainID        = "chain-id-2"
@@ -23,6 +27,11 @@ func main(cur realm) {
 	)
 	clientID := core.CreateClient(cross(cur), clientState, consensusState)
 	core.RegisterCounterparty(cross(cur), clientID, [][]byte{[]byte("iavlStoreKey"), []byte("prefix2")}, "07-tendermint-2")
+
+	// Advance block time past the trusting period to expire the client.
+	ctx := testing.GetContext()
+	ctx.Time = time.Now().Add(clientState.TrustingPeriod)
+	testing.SetContext(ctx)
 
 	println(transfer.Render(""))
 }
@@ -36,7 +45,7 @@ func main(cur realm) {
 //
 // Trigger an IBC transfer from your wallet. Pick the client of the destination chain:
 //
-// - [send via `07-tendermint-1`](/r/aib/main$help&func=Transfer&amount=&clientID=07-tendermint-1&denom=&memo=&receiver=&timeoutTimestamp=1234571490) — Active, trusted height `2/2` ([client details](/r/aib/ibc/core:clients/07-tendermint-1))
+// - `07-tendermint-1` — Expired, trusted height `2/2` ([client details](/r/aib/ibc/core:clients/07-tendermint-1))
 //
 // ## Vouchers (0)
 //

--- a/gno.land/r/aib/ibc/apps/transfer/render.gno
+++ b/gno.land/r/aib/ibc/apps/transfer/render.gno
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"gno.land/p/aib/ibc/lightclient"
 	"gno.land/p/aib/jsonpage"
 	"gno.land/p/moul/txlink"
 	"gno.land/p/nt/mux/v0"
@@ -186,10 +187,20 @@ func renderTransferLinks() string {
 
 	out.WriteString("Trigger an IBC transfer from your wallet. Pick the client of the destination chain:\n\n")
 	for _, clientID := range clientIDs {
-		out.WriteString(ufmt.Sprintf(
-			"- [send via `%s`](%s) ([client details](/r/aib/ibc/core:clients/%s))\n",
-			clientID, newTransferLink(clientID, "", "").URL(), clientID,
-		))
+		status := core.ClientStatus(clientID)
+		height := core.ClientLatestHeight(clientID)
+		if status == lightclient.Active {
+			out.WriteString(ufmt.Sprintf(
+				"- [send via `%s`](%s) — %s, trusted height `%s` ([client details](/r/aib/ibc/core:clients/%s))\n",
+				clientID, newTransferLink(clientID, "", "").URL(), status, height, clientID,
+			))
+		} else {
+			// Non-active client: no send link, since packets can't be sent.
+			out.WriteString(ufmt.Sprintf(
+				"- `%s` — %s, trusted height `%s` ([client details](/r/aib/ibc/core:clients/%s))\n",
+				clientID, status, height, clientID,
+			))
+		}
 	}
 
 	// Per-voucher links: send back via IBC, plus local GRC20 send/approve.

--- a/gno.land/r/aib/ibc/core/client.gno
+++ b/gno.land/r/aib/ibc/core/client.gno
@@ -58,6 +58,30 @@ func ClientIDs() []string {
 	return ids
 }
 
+// ClientLatestHeight returns the latest (highest) consensus height the given
+// client has been updated to, formatted as "<revision>/<height>". This is the
+// client's latest trusted height. Returns "" if the client is unknown.
+// Intended for read-only callers (UIs) that want to surface how up-to-date a
+// client is.
+func ClientLatestHeight(clientID string) string {
+	c := store.getClient(clientID)
+	if c == nil {
+		return ""
+	}
+	return c.lightClient.LatestHeight().String()
+}
+
+// ClientStatus returns the status of the given client (Active, Expired,
+// Frozen, ...). Returns "" if the client is unknown. Intended for read-only
+// callers (UIs) that want to surface whether a client is usable.
+func ClientStatus(clientID string) string {
+	c := store.getClient(clientID)
+	if c == nil {
+		return ""
+	}
+	return c.lightClient.Status()
+}
+
 // RegisterCounterparty will register the IBC v2 counterparty info for the
 // given clientID. It must be called by the same relayer that called
 // CreateClient.


### PR DESCRIPTION
## What

The Transfer section of the transfer app's render page listed each client by ID only:

```
- send via `07-tendermint-1` (client details)
- send via `07-tendermint-2` (client details)
```

When several clients track the same chain, there was no way to tell at a glance which one is up-to-date — or even usable. This adds the client's **status** and **latest trusted height** to each row, and drops the send link for clients that aren't `Active`:

```
- send via `07-tendermint-1` — Active, trusted height `2/2` (client details)
- `07-tendermint-2` — Expired, trusted height `2/2` (client details)
```

A non-active client (Expired/Frozen) can't send packets, so it's still listed with its status and height but **without** a `send via` link.

## How

- **`core/client.gno`**: two read-only accessors, since the transfer realm can't reach core's private `client` struct:
  - `ClientLatestHeight(clientID) string` — latest trusted height as `<revision>/<height>` (or `""` if unknown).
  - `ClientStatus(clientID) string` — `Active` / `Expired` / `Frozen` / … (or `""` if unknown).
- **`transfer/render.gno`**: `renderTransferLinks()` shows `<status>, trusted height <h>` per client, and only renders the `Transfer` txlink when the status is `lightclient.Active`.

Note: returning the `lightclient.Interface` directly was considered but rejected — it exposes mutating methods (`UpdateState`, `Initialize`, `RecoverClient`, …) that would let any caller bypass core's relayer-gated client lifecycle. The string accessors keep the boundary read-only.

## Test

- Updated `z0bb_render_home_with_client_filetest.gno` golden output (now shows `Active`).
- Added `z0bbb_render_home_expired_client_filetest.gno`: creates a client, advances block time past the trusting period to expire it, and asserts the row has no `send via` link.
- `go tool gno test ./gno.land/r/aib/ibc/core/ ./gno.land/r/aib/ibc/apps/transfer/` — both pass.